### PR TITLE
HIS-258: Translatable map layers

### DIFF
--- a/conf/cmi/core.entity_form_display.node.map_layer.default.yml
+++ b/conf/cmi/core.entity_form_display.node.map_layer.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - node.type.map_layer
   module:
     - content_moderation
+    - hdbt_admin_editorial
     - paragraphs
     - path
     - scheduler
@@ -21,7 +22,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 8
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -32,12 +33,6 @@ content:
     settings:
       size: 60
       placeholder: ''
-    third_party_settings: {  }
-  field_map_api:
-    type: options_select
-    weight: 5
-    region: content
-    settings: {  }
     third_party_settings: {  }
   field_map_api_endpoints:
     type: paragraphs
@@ -58,22 +53,6 @@ content:
         collapse_edit_all: collapse_edit_all
         duplicate: duplicate
     third_party_settings: {  }
-  field_map_era:
-    type: string_textfield
-    weight: 4
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_map_wms_title:
-    type: string_textfield
-    weight: 6
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
   langcode:
     type: language_select
     weight: 0
@@ -83,39 +62,39 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 100
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 11
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 9
+    weight: 6
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 12
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 15
+    weight: 13
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 10
+    weight: 7
     region: content
     settings:
       display_label: true
@@ -128,9 +107,14 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  translation:
+    weight: 8
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 7
+    weight: 4
     region: content
     settings:
       match_operator: CONTAINS
@@ -140,13 +124,16 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 13
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 14
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  field_map_api: true
+  field_map_era: true
+  field_map_wms_title: true

--- a/conf/cmi/field.field.node.map_layer.field_layer_title.yml
+++ b/conf/cmi/field.field.node.map_layer.field_layer_title.yml
@@ -12,7 +12,7 @@ bundle: map_layer
 label: 'Layer title'
 description: 'This will be the name of the layer in the map layer selector.'
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/conf/cmi/field.field.node.map_layer.field_map_api.yml
+++ b/conf/cmi/field.field.node.map_layer.field_map_api.yml
@@ -14,7 +14,7 @@ bundle: map_layer
 label: 'Map API (DEPRECATED)'
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/conf/cmi/field.field.node.map_layer.field_map_api.yml
+++ b/conf/cmi/field.field.node.map_layer.field_map_api.yml
@@ -13,7 +13,7 @@ entity_type: node
 bundle: map_layer
 label: 'Map API (DEPRECATED)'
 description: ''
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/conf/cmi/field.field.node.map_layer.field_map_api_endpoints.yml
+++ b/conf/cmi/field.field.node.map_layer.field_map_api_endpoints.yml
@@ -15,7 +15,7 @@ bundle: map_layer
 label: 'Map API endpoints'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/conf/cmi/field.field.node.map_layer.field_map_era.yml
+++ b/conf/cmi/field.field.node.map_layer.field_map_era.yml
@@ -12,7 +12,7 @@ bundle: map_layer
 label: 'Map era (DEPRECATED)'
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/conf/cmi/field.field.node.map_layer.field_map_era.yml
+++ b/conf/cmi/field.field.node.map_layer.field_map_era.yml
@@ -11,7 +11,7 @@ entity_type: node
 bundle: map_layer
 label: 'Map era (DEPRECATED)'
 description: ''
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/conf/cmi/field.field.node.map_layer.field_map_wms_title.yml
+++ b/conf/cmi/field.field.node.map_layer.field_map_wms_title.yml
@@ -12,7 +12,7 @@ bundle: map_layer
 label: 'WMS title (DEPRECATED)'
 description: 'The title of the map in the Helsinki spatial data service (e.g. Opaskartta_1940).'
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/conf/cmi/field.field.node.map_layer.field_map_wms_title.yml
+++ b/conf/cmi/field.field.node.map_layer.field_map_wms_title.yml
@@ -11,7 +11,7 @@ entity_type: node
 bundle: map_layer
 label: 'WMS title (DEPRECATED)'
 description: 'The title of the map in the Helsinki spatial data service (e.g. Opaskartta_1940).'
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/conf/cmi/language.content_settings.media.file.yml
+++ b/conf/cmi/language.content_settings.media.file.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 _core:
   default_config_hash: rup-w6uPAmGhsqOpxHkoHNx1E2nof8peWIMR3CHUOu8
 id: media.file

--- a/conf/cmi/language.content_settings.media.image.yml
+++ b/conf/cmi/language.content_settings.media.image.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 _core:
   default_config_hash: I3xj--oU7S2jOMuZHlT3vTfM7WPH30XtCbo2gO_Ntf0
 id: media.image

--- a/conf/cmi/language.content_settings.media.remote_video.yml
+++ b/conf/cmi/language.content_settings.media.remote_video.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 _core:
   default_config_hash: W7YfIhAOIwvyPQmKlhuh5d94_oZSSsj83AYQaegVafs
 id: media.remote_video

--- a/conf/cmi/language.content_settings.media.soundcloud.yml
+++ b/conf/cmi/language.content_settings.media.soundcloud.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 _core:
   default_config_hash: CTeM98pvlMZ4uvX52DfiTqpxVhdXZA86ba0crMGMIVg
 id: media.soundcloud

--- a/conf/cmi/language.content_settings.node.article.yml
+++ b/conf/cmi/language.content_settings.node.article.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '1'
 _core:
   default_config_hash: XnP46wu29yoXuG94i1EI_2aNPiOXWmdgocoMHTFBujA
 id: node.article

--- a/conf/cmi/language.content_settings.node.landing_page.yml
+++ b/conf/cmi/language.content_settings.node.landing_page.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 _core:
   default_config_hash: UrEWFwFHhJNNrHsT2CbI-8FK7KIgmDq0xV6ahjaavBM
 id: node.landing_page

--- a/conf/cmi/language.content_settings.node.listing_page.yml
+++ b/conf/cmi/language.content_settings.node.listing_page.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: node.listing_page
 target_entity_type_id: node
 target_bundle: listing_page

--- a/conf/cmi/language.content_settings.node.map_layer.yml
+++ b/conf/cmi/language.content_settings.node.map_layer.yml
@@ -4,8 +4,15 @@ status: true
 dependencies:
   config:
     - node.type.map_layer
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: node.map_layer
 target_entity_type_id: node
 target_bundle: map_layer
-default_langcode: site_default
-language_alterable: false
+default_langcode: fi
+language_alterable: true

--- a/conf/cmi/language.content_settings.node.map_page.yml
+++ b/conf/cmi/language.content_settings.node.map_page.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: node.map_page
 target_entity_type_id: node
 target_bundle: map_page

--- a/conf/cmi/language.content_settings.node.page.yml
+++ b/conf/cmi/language.content_settings.node.page.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 _core:
   default_config_hash: gmtmgLpPQOcKE9BA_eKfrCXtoWVO63kmcfythbJiz5Q
 id: node.page

--- a/conf/cmi/language.content_settings.paragraph.accordion.yml
+++ b/conf/cmi/language.content_settings.paragraph.accordion.yml
@@ -1,9 +1,9 @@
-uuid: f22659b3-5067-4d5a-9897-dcf29c9f8574
+uuid: f1dbce56-d67d-4541-a926-f5073e9e619e
 langcode: en
 status: true
 dependencies:
   config:
-    - media.type.helfi_chart
+    - paragraphs.paragraphs_type.accordion
   module:
     - content_translation
 third_party_settings:
@@ -11,10 +11,8 @@ third_party_settings:
     enabled: false
     bundle_settings:
       untranslatable_fields_hide: '0'
-_core:
-  default_config_hash: 2BVN4f7oVA6fKcWq9zF90vKpBQ122PgyhnrbvoSn_gk
-id: media.helfi_chart
-target_entity_type_id: media
-target_bundle: helfi_chart
+id: paragraph.accordion
+target_entity_type_id: paragraph
+target_bundle: accordion
 default_langcode: site_default
 language_alterable: false

--- a/conf/cmi/language.content_settings.paragraph.accordion_item.yml
+++ b/conf/cmi/language.content_settings.paragraph.accordion_item.yml
@@ -1,9 +1,9 @@
-uuid: f22659b3-5067-4d5a-9897-dcf29c9f8574
+uuid: 0031fad8-234e-4d61-944e-352a8761f957
 langcode: en
 status: true
 dependencies:
   config:
-    - media.type.helfi_chart
+    - paragraphs.paragraphs_type.accordion_item
   module:
     - content_translation
 third_party_settings:
@@ -11,10 +11,8 @@ third_party_settings:
     enabled: false
     bundle_settings:
       untranslatable_fields_hide: '0'
-_core:
-  default_config_hash: 2BVN4f7oVA6fKcWq9zF90vKpBQ122PgyhnrbvoSn_gk
-id: media.helfi_chart
-target_entity_type_id: media
-target_bundle: helfi_chart
+id: paragraph.accordion_item
+target_entity_type_id: paragraph
+target_bundle: accordion_item
 default_langcode: site_default
 language_alterable: false

--- a/conf/cmi/language.content_settings.paragraph.banner.yml
+++ b/conf/cmi/language.content_settings.paragraph.banner.yml
@@ -1,9 +1,9 @@
-uuid: f22659b3-5067-4d5a-9897-dcf29c9f8574
+uuid: d47d13db-26a5-4aed-9ffa-e440b08b7944
 langcode: en
 status: true
 dependencies:
   config:
-    - media.type.helfi_chart
+    - paragraphs.paragraphs_type.banner
   module:
     - content_translation
 third_party_settings:
@@ -11,10 +11,8 @@ third_party_settings:
     enabled: false
     bundle_settings:
       untranslatable_fields_hide: '0'
-_core:
-  default_config_hash: 2BVN4f7oVA6fKcWq9zF90vKpBQ122PgyhnrbvoSn_gk
-id: media.helfi_chart
-target_entity_type_id: media
-target_bundle: helfi_chart
+id: paragraph.banner
+target_entity_type_id: paragraph
+target_bundle: banner
 default_langcode: site_default
 language_alterable: false

--- a/conf/cmi/language.content_settings.paragraph.chart.yml
+++ b/conf/cmi/language.content_settings.paragraph.chart.yml
@@ -1,9 +1,9 @@
-uuid: f22659b3-5067-4d5a-9897-dcf29c9f8574
+uuid: c7230a00-a470-46ce-b53c-727a1d872a97
 langcode: en
 status: true
 dependencies:
   config:
-    - media.type.helfi_chart
+    - paragraphs.paragraphs_type.chart
   module:
     - content_translation
 third_party_settings:
@@ -11,10 +11,8 @@ third_party_settings:
     enabled: false
     bundle_settings:
       untranslatable_fields_hide: '0'
-_core:
-  default_config_hash: 2BVN4f7oVA6fKcWq9zF90vKpBQ122PgyhnrbvoSn_gk
-id: media.helfi_chart
-target_entity_type_id: media
-target_bundle: helfi_chart
+id: paragraph.chart
+target_entity_type_id: paragraph
+target_bundle: chart
 default_langcode: site_default
 language_alterable: false

--- a/conf/cmi/language.content_settings.paragraph.columns.yml
+++ b/conf/cmi/language.content_settings.paragraph.columns.yml
@@ -1,9 +1,9 @@
-uuid: f22659b3-5067-4d5a-9897-dcf29c9f8574
+uuid: 92460451-5719-4180-a32e-0a431da8c222
 langcode: en
 status: true
 dependencies:
   config:
-    - media.type.helfi_chart
+    - paragraphs.paragraphs_type.columns
   module:
     - content_translation
 third_party_settings:
@@ -11,10 +11,8 @@ third_party_settings:
     enabled: false
     bundle_settings:
       untranslatable_fields_hide: '0'
-_core:
-  default_config_hash: 2BVN4f7oVA6fKcWq9zF90vKpBQ122PgyhnrbvoSn_gk
-id: media.helfi_chart
-target_entity_type_id: media
-target_bundle: helfi_chart
+id: paragraph.columns
+target_entity_type_id: paragraph
+target_bundle: columns
 default_langcode: site_default
 language_alterable: false

--- a/conf/cmi/language.content_settings.paragraph.content_cards.yml
+++ b/conf/cmi/language.content_settings.paragraph.content_cards.yml
@@ -1,9 +1,9 @@
-uuid: f22659b3-5067-4d5a-9897-dcf29c9f8574
+uuid: 43b6f876-c9f6-40aa-ba22-402f9f9d7af1
 langcode: en
 status: true
 dependencies:
   config:
-    - media.type.helfi_chart
+    - paragraphs.paragraphs_type.content_cards
   module:
     - content_translation
 third_party_settings:
@@ -11,10 +11,8 @@ third_party_settings:
     enabled: false
     bundle_settings:
       untranslatable_fields_hide: '0'
-_core:
-  default_config_hash: 2BVN4f7oVA6fKcWq9zF90vKpBQ122PgyhnrbvoSn_gk
-id: media.helfi_chart
-target_entity_type_id: media
-target_bundle: helfi_chart
+id: paragraph.content_cards
+target_entity_type_id: paragraph
+target_bundle: content_cards
 default_langcode: site_default
 language_alterable: false

--- a/conf/cmi/language.content_settings.paragraph.content_liftup.yml
+++ b/conf/cmi/language.content_settings.paragraph.content_liftup.yml
@@ -1,9 +1,9 @@
-uuid: f22659b3-5067-4d5a-9897-dcf29c9f8574
+uuid: 5b0af10a-67cb-4f1e-b7c0-0e90d9f5db50
 langcode: en
 status: true
 dependencies:
   config:
-    - media.type.helfi_chart
+    - paragraphs.paragraphs_type.content_liftup
   module:
     - content_translation
 third_party_settings:
@@ -11,10 +11,8 @@ third_party_settings:
     enabled: false
     bundle_settings:
       untranslatable_fields_hide: '0'
-_core:
-  default_config_hash: 2BVN4f7oVA6fKcWq9zF90vKpBQ122PgyhnrbvoSn_gk
-id: media.helfi_chart
-target_entity_type_id: media
-target_bundle: helfi_chart
+id: paragraph.content_liftup
+target_entity_type_id: paragraph
+target_bundle: content_liftup
 default_langcode: site_default
 language_alterable: false

--- a/conf/cmi/language.content_settings.paragraph.from_library.yml
+++ b/conf/cmi/language.content_settings.paragraph.from_library.yml
@@ -1,9 +1,9 @@
-uuid: f22659b3-5067-4d5a-9897-dcf29c9f8574
+uuid: f89b3f3c-5449-4ef3-a1e0-033440be81a9
 langcode: en
 status: true
 dependencies:
   config:
-    - media.type.helfi_chart
+    - paragraphs.paragraphs_type.from_library
   module:
     - content_translation
 third_party_settings:
@@ -11,10 +11,8 @@ third_party_settings:
     enabled: false
     bundle_settings:
       untranslatable_fields_hide: '0'
-_core:
-  default_config_hash: 2BVN4f7oVA6fKcWq9zF90vKpBQ122PgyhnrbvoSn_gk
-id: media.helfi_chart
-target_entity_type_id: media
-target_bundle: helfi_chart
+id: paragraph.from_library
+target_entity_type_id: paragraph
+target_bundle: from_library
 default_langcode: site_default
 language_alterable: false

--- a/conf/cmi/language.content_settings.paragraph.gallery.yml
+++ b/conf/cmi/language.content_settings.paragraph.gallery.yml
@@ -1,9 +1,9 @@
-uuid: f22659b3-5067-4d5a-9897-dcf29c9f8574
+uuid: 7a1d950c-a8cb-48c4-936d-67c91d761a4c
 langcode: en
 status: true
 dependencies:
   config:
-    - media.type.helfi_chart
+    - paragraphs.paragraphs_type.gallery
   module:
     - content_translation
 third_party_settings:
@@ -11,10 +11,8 @@ third_party_settings:
     enabled: false
     bundle_settings:
       untranslatable_fields_hide: '0'
-_core:
-  default_config_hash: 2BVN4f7oVA6fKcWq9zF90vKpBQ122PgyhnrbvoSn_gk
-id: media.helfi_chart
-target_entity_type_id: media
-target_bundle: helfi_chart
+id: paragraph.gallery
+target_entity_type_id: paragraph
+target_bundle: gallery
 default_langcode: site_default
 language_alterable: false

--- a/conf/cmi/language.content_settings.paragraph.gallery_slide.yml
+++ b/conf/cmi/language.content_settings.paragraph.gallery_slide.yml
@@ -1,9 +1,9 @@
-uuid: f22659b3-5067-4d5a-9897-dcf29c9f8574
+uuid: 0c34f6be-70a6-4a20-a013-68abdaadc0b8
 langcode: en
 status: true
 dependencies:
   config:
-    - media.type.helfi_chart
+    - paragraphs.paragraphs_type.gallery_slide
   module:
     - content_translation
 third_party_settings:
@@ -11,10 +11,8 @@ third_party_settings:
     enabled: false
     bundle_settings:
       untranslatable_fields_hide: '0'
-_core:
-  default_config_hash: 2BVN4f7oVA6fKcWq9zF90vKpBQ122PgyhnrbvoSn_gk
-id: media.helfi_chart
-target_entity_type_id: media
-target_bundle: helfi_chart
+id: paragraph.gallery_slide
+target_entity_type_id: paragraph
+target_bundle: gallery_slide
 default_langcode: site_default
 language_alterable: false

--- a/conf/cmi/language.content_settings.paragraph.hero.yml
+++ b/conf/cmi/language.content_settings.paragraph.hero.yml
@@ -1,9 +1,9 @@
-uuid: f22659b3-5067-4d5a-9897-dcf29c9f8574
+uuid: 18e5618b-8997-4a26-8ef6-1b40b8429f22
 langcode: en
 status: true
 dependencies:
   config:
-    - media.type.helfi_chart
+    - paragraphs.paragraphs_type.hero
   module:
     - content_translation
 third_party_settings:
@@ -11,10 +11,8 @@ third_party_settings:
     enabled: false
     bundle_settings:
       untranslatable_fields_hide: '0'
-_core:
-  default_config_hash: 2BVN4f7oVA6fKcWq9zF90vKpBQ122PgyhnrbvoSn_gk
-id: media.helfi_chart
-target_entity_type_id: media
-target_bundle: helfi_chart
+id: paragraph.hero
+target_entity_type_id: paragraph
+target_bundle: hero
 default_langcode: site_default
 language_alterable: false

--- a/conf/cmi/language.content_settings.paragraph.image.yml
+++ b/conf/cmi/language.content_settings.paragraph.image.yml
@@ -1,9 +1,9 @@
-uuid: f22659b3-5067-4d5a-9897-dcf29c9f8574
+uuid: ea76b17d-5740-4e4d-b27d-724da5a156c0
 langcode: en
 status: true
 dependencies:
   config:
-    - media.type.helfi_chart
+    - paragraphs.paragraphs_type.image
   module:
     - content_translation
 third_party_settings:
@@ -11,10 +11,8 @@ third_party_settings:
     enabled: false
     bundle_settings:
       untranslatable_fields_hide: '0'
-_core:
-  default_config_hash: 2BVN4f7oVA6fKcWq9zF90vKpBQ122PgyhnrbvoSn_gk
-id: media.helfi_chart
-target_entity_type_id: media
-target_bundle: helfi_chart
+id: paragraph.image
+target_entity_type_id: paragraph
+target_bundle: image
 default_langcode: site_default
 language_alterable: false

--- a/conf/cmi/language.content_settings.paragraph.liftup_with_image.yml
+++ b/conf/cmi/language.content_settings.paragraph.liftup_with_image.yml
@@ -1,9 +1,9 @@
-uuid: f22659b3-5067-4d5a-9897-dcf29c9f8574
+uuid: ceba388c-34a4-4f95-b168-5e5d38d80df3
 langcode: en
 status: true
 dependencies:
   config:
-    - media.type.helfi_chart
+    - paragraphs.paragraphs_type.liftup_with_image
   module:
     - content_translation
 third_party_settings:
@@ -11,10 +11,8 @@ third_party_settings:
     enabled: false
     bundle_settings:
       untranslatable_fields_hide: '0'
-_core:
-  default_config_hash: 2BVN4f7oVA6fKcWq9zF90vKpBQ122PgyhnrbvoSn_gk
-id: media.helfi_chart
-target_entity_type_id: media
-target_bundle: helfi_chart
+id: paragraph.liftup_with_image
+target_entity_type_id: paragraph
+target_bundle: liftup_with_image
 default_langcode: site_default
 language_alterable: false

--- a/conf/cmi/language.content_settings.paragraph.list_of_links.yml
+++ b/conf/cmi/language.content_settings.paragraph.list_of_links.yml
@@ -1,9 +1,9 @@
-uuid: f22659b3-5067-4d5a-9897-dcf29c9f8574
+uuid: 33a16488-9d14-4cc3-b4a1-98c811289355
 langcode: en
 status: true
 dependencies:
   config:
-    - media.type.helfi_chart
+    - paragraphs.paragraphs_type.list_of_links
   module:
     - content_translation
 third_party_settings:
@@ -11,10 +11,8 @@ third_party_settings:
     enabled: false
     bundle_settings:
       untranslatable_fields_hide: '0'
-_core:
-  default_config_hash: 2BVN4f7oVA6fKcWq9zF90vKpBQ122PgyhnrbvoSn_gk
-id: media.helfi_chart
-target_entity_type_id: media
-target_bundle: helfi_chart
+id: paragraph.list_of_links
+target_entity_type_id: paragraph
+target_bundle: list_of_links
 default_langcode: site_default
 language_alterable: false

--- a/conf/cmi/language.content_settings.paragraph.list_of_links_item.yml
+++ b/conf/cmi/language.content_settings.paragraph.list_of_links_item.yml
@@ -1,9 +1,9 @@
-uuid: f22659b3-5067-4d5a-9897-dcf29c9f8574
+uuid: cd21efba-6d92-4b89-856b-c43b8be23a01
 langcode: en
 status: true
 dependencies:
   config:
-    - media.type.helfi_chart
+    - paragraphs.paragraphs_type.list_of_links_item
   module:
     - content_translation
 third_party_settings:
@@ -11,10 +11,8 @@ third_party_settings:
     enabled: false
     bundle_settings:
       untranslatable_fields_hide: '0'
-_core:
-  default_config_hash: 2BVN4f7oVA6fKcWq9zF90vKpBQ122PgyhnrbvoSn_gk
-id: media.helfi_chart
-target_entity_type_id: media
-target_bundle: helfi_chart
+id: paragraph.list_of_links_item
+target_entity_type_id: paragraph
+target_bundle: list_of_links_item
 default_langcode: site_default
 language_alterable: false

--- a/conf/cmi/language.content_settings.paragraph.map_api_endpoint.yml
+++ b/conf/cmi/language.content_settings.paragraph.map_api_endpoint.yml
@@ -1,9 +1,9 @@
-uuid: f22659b3-5067-4d5a-9897-dcf29c9f8574
+uuid: 55e4a006-d5b9-4428-8193-11e349bd5d2a
 langcode: en
 status: true
 dependencies:
   config:
-    - media.type.helfi_chart
+    - paragraphs.paragraphs_type.map_api_endpoint
   module:
     - content_translation
 third_party_settings:
@@ -11,10 +11,8 @@ third_party_settings:
     enabled: false
     bundle_settings:
       untranslatable_fields_hide: '0'
-_core:
-  default_config_hash: 2BVN4f7oVA6fKcWq9zF90vKpBQ122PgyhnrbvoSn_gk
-id: media.helfi_chart
-target_entity_type_id: media
-target_bundle: helfi_chart
+id: paragraph.map_api_endpoint
+target_entity_type_id: paragraph
+target_bundle: map_api_endpoint
 default_langcode: site_default
 language_alterable: false

--- a/conf/cmi/language.content_settings.paragraph.remote_video.yml
+++ b/conf/cmi/language.content_settings.paragraph.remote_video.yml
@@ -1,9 +1,9 @@
-uuid: f22659b3-5067-4d5a-9897-dcf29c9f8574
+uuid: 80a8799b-a986-4196-88fd-49e50474106d
 langcode: en
 status: true
 dependencies:
   config:
-    - media.type.helfi_chart
+    - paragraphs.paragraphs_type.remote_video
   module:
     - content_translation
 third_party_settings:
@@ -11,10 +11,8 @@ third_party_settings:
     enabled: false
     bundle_settings:
       untranslatable_fields_hide: '0'
-_core:
-  default_config_hash: 2BVN4f7oVA6fKcWq9zF90vKpBQ122PgyhnrbvoSn_gk
-id: media.helfi_chart
-target_entity_type_id: media
-target_bundle: helfi_chart
+id: paragraph.remote_video
+target_entity_type_id: paragraph
+target_bundle: remote_video
 default_langcode: site_default
 language_alterable: false

--- a/conf/cmi/language.content_settings.paragraph.sidebar_text.yml
+++ b/conf/cmi/language.content_settings.paragraph.sidebar_text.yml
@@ -1,9 +1,9 @@
-uuid: f22659b3-5067-4d5a-9897-dcf29c9f8574
+uuid: fd6dd154-b0b0-4e68-93b5-5044989b0c7b
 langcode: en
 status: true
 dependencies:
   config:
-    - media.type.helfi_chart
+    - paragraphs.paragraphs_type.sidebar_text
   module:
     - content_translation
 third_party_settings:
@@ -11,10 +11,8 @@ third_party_settings:
     enabled: false
     bundle_settings:
       untranslatable_fields_hide: '0'
-_core:
-  default_config_hash: 2BVN4f7oVA6fKcWq9zF90vKpBQ122PgyhnrbvoSn_gk
-id: media.helfi_chart
-target_entity_type_id: media
-target_bundle: helfi_chart
+id: paragraph.sidebar_text
+target_entity_type_id: paragraph
+target_bundle: sidebar_text
 default_langcode: site_default
 language_alterable: false

--- a/conf/cmi/language.content_settings.paragraph.text.yml
+++ b/conf/cmi/language.content_settings.paragraph.text.yml
@@ -1,9 +1,9 @@
-uuid: f22659b3-5067-4d5a-9897-dcf29c9f8574
+uuid: 2427514a-4924-4bef-af69-164d2f8357a2
 langcode: en
 status: true
 dependencies:
   config:
-    - media.type.helfi_chart
+    - paragraphs.paragraphs_type.text
   module:
     - content_translation
 third_party_settings:
@@ -11,10 +11,8 @@ third_party_settings:
     enabled: false
     bundle_settings:
       untranslatable_fields_hide: '0'
-_core:
-  default_config_hash: 2BVN4f7oVA6fKcWq9zF90vKpBQ122PgyhnrbvoSn_gk
-id: media.helfi_chart
-target_entity_type_id: media
-target_bundle: helfi_chart
+id: paragraph.text
+target_entity_type_id: paragraph
+target_bundle: text
 default_langcode: site_default
 language_alterable: false

--- a/conf/cmi/language.content_settings.paragraph.timeline.yml
+++ b/conf/cmi/language.content_settings.paragraph.timeline.yml
@@ -1,9 +1,9 @@
-uuid: f22659b3-5067-4d5a-9897-dcf29c9f8574
+uuid: a3b193fc-231b-46f1-bd6f-4b4f2b056f5e
 langcode: en
 status: true
 dependencies:
   config:
-    - media.type.helfi_chart
+    - paragraphs.paragraphs_type.timeline
   module:
     - content_translation
 third_party_settings:
@@ -11,10 +11,8 @@ third_party_settings:
     enabled: false
     bundle_settings:
       untranslatable_fields_hide: '0'
-_core:
-  default_config_hash: 2BVN4f7oVA6fKcWq9zF90vKpBQ122PgyhnrbvoSn_gk
-id: media.helfi_chart
-target_entity_type_id: media
-target_bundle: helfi_chart
+id: paragraph.timeline
+target_entity_type_id: paragraph
+target_bundle: timeline
 default_langcode: site_default
 language_alterable: false

--- a/conf/cmi/language.content_settings.paragraph.timeline_item.yml
+++ b/conf/cmi/language.content_settings.paragraph.timeline_item.yml
@@ -1,9 +1,9 @@
-uuid: f22659b3-5067-4d5a-9897-dcf29c9f8574
+uuid: bdf25c0a-d9af-4dee-98e6-13bfc640aea7
 langcode: en
 status: true
 dependencies:
   config:
-    - media.type.helfi_chart
+    - paragraphs.paragraphs_type.timeline_item
   module:
     - content_translation
 third_party_settings:
@@ -11,10 +11,8 @@ third_party_settings:
     enabled: false
     bundle_settings:
       untranslatable_fields_hide: '0'
-_core:
-  default_config_hash: 2BVN4f7oVA6fKcWq9zF90vKpBQ122PgyhnrbvoSn_gk
-id: media.helfi_chart
-target_entity_type_id: media
-target_bundle: helfi_chart
+id: paragraph.timeline_item
+target_entity_type_id: paragraph
+target_bundle: timeline_item
 default_langcode: site_default
 language_alterable: false

--- a/conf/cmi/language.content_settings.paragraphs_library_item.paragraphs_library_item.yml
+++ b/conf/cmi/language.content_settings.paragraphs_library_item.paragraphs_library_item.yml
@@ -1,20 +1,17 @@
-uuid: f22659b3-5067-4d5a-9897-dcf29c9f8574
+uuid: d5f8b792-c5d2-4ef7-8601-ea4a360480da
 langcode: en
 status: true
 dependencies:
-  config:
-    - media.type.helfi_chart
   module:
     - content_translation
+    - paragraphs_library
 third_party_settings:
   content_translation:
     enabled: false
     bundle_settings:
       untranslatable_fields_hide: '0'
-_core:
-  default_config_hash: 2BVN4f7oVA6fKcWq9zF90vKpBQ122PgyhnrbvoSn_gk
-id: media.helfi_chart
-target_entity_type_id: media
-target_bundle: helfi_chart
+id: paragraphs_library_item.paragraphs_library_item
+target_entity_type_id: paragraphs_library_item
+target_bundle: paragraphs_library_item
 default_langcode: site_default
 language_alterable: false

--- a/conf/cmi/language.content_settings.taxonomy_term.authors.yml
+++ b/conf/cmi/language.content_settings.taxonomy_term.authors.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: taxonomy_term.authors
 target_entity_type_id: taxonomy_term
 target_bundle: authors

--- a/conf/cmi/language.content_settings.taxonomy_term.buildings.yml
+++ b/conf/cmi/language.content_settings.taxonomy_term.buildings.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: taxonomy_term.buildings
 target_entity_type_id: taxonomy_term
 target_bundle: buildings

--- a/conf/cmi/language.content_settings.taxonomy_term.copyrights.yml
+++ b/conf/cmi/language.content_settings.taxonomy_term.copyrights.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: taxonomy_term.copyrights
 target_entity_type_id: taxonomy_term
 target_bundle: copyrights

--- a/conf/cmi/language.content_settings.taxonomy_term.formats.yml
+++ b/conf/cmi/language.content_settings.taxonomy_term.formats.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: taxonomy_term.formats
 target_entity_type_id: taxonomy_term
 target_bundle: formats

--- a/conf/cmi/language.content_settings.taxonomy_term.keywords.yml
+++ b/conf/cmi/language.content_settings.taxonomy_term.keywords.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 _core:
   default_config_hash: ZMPJneHpl3fQ2L7855yQOIVii5Xn-TQaqljhB7tP-7o
 id: taxonomy_term.keywords

--- a/conf/cmi/language.content_settings.taxonomy_term.languages.yml
+++ b/conf/cmi/language.content_settings.taxonomy_term.languages.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: taxonomy_term.languages
 target_entity_type_id: taxonomy_term
 target_bundle: languages

--- a/conf/cmi/language.content_settings.taxonomy_term.neighbourhoods.yml
+++ b/conf/cmi/language.content_settings.taxonomy_term.neighbourhoods.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: taxonomy_term.neighbourhoods
 target_entity_type_id: taxonomy_term
 target_bundle: neighbourhoods

--- a/conf/cmi/language.content_settings.taxonomy_term.phenomena.yml
+++ b/conf/cmi/language.content_settings.taxonomy_term.phenomena.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: taxonomy_term.phenomena
 target_entity_type_id: taxonomy_term
 target_bundle: phenomena

--- a/conf/cmi/language.content_settings.taxonomy_term.turning_points.yml
+++ b/conf/cmi/language.content_settings.taxonomy_term.turning_points.yml
@@ -9,6 +9,8 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: taxonomy_term.turning_points
 target_entity_type_id: taxonomy_term
 target_bundle: turning_points

--- a/conf/cmi/language.content_settings.user.user.yml
+++ b/conf/cmi/language.content_settings.user.user.yml
@@ -1,20 +1,17 @@
-uuid: f22659b3-5067-4d5a-9897-dcf29c9f8574
+uuid: 35831a79-b0b7-4777-afe4-e7c02a0096aa
 langcode: en
 status: true
 dependencies:
-  config:
-    - media.type.helfi_chart
   module:
     - content_translation
+    - user
 third_party_settings:
   content_translation:
     enabled: false
     bundle_settings:
       untranslatable_fields_hide: '0'
-_core:
-  default_config_hash: 2BVN4f7oVA6fKcWq9zF90vKpBQ122PgyhnrbvoSn_gk
-id: media.helfi_chart
-target_entity_type_id: media
-target_bundle: helfi_chart
+id: user.user
+target_entity_type_id: user
+target_bundle: user
 default_langcode: site_default
 language_alterable: false

--- a/public/modules/custom/helhist_map/helhist_map.module
+++ b/public/modules/custom/helhist_map/helhist_map.module
@@ -106,7 +106,7 @@ function helhist_map_form_alter(&$form, FormStateInterface $form_state, $form_id
 
   $form_id = 'views-exposed-form-combined-map-block--2';
   $select_field = 'field_keywords_target_id';
-  $taxonomy_field = 'node__field_keywords';
+  $taxonomy_field = 'field_keywords';
 
   if ($form['#id'] == $form_id) {
     $active_terms = _get_active_terms($taxonomy_field, $select_field);
@@ -139,11 +139,13 @@ function _get_active_terms($taxonomy_field, $select_field) {
 
   // Find taxonomy terms that link to node type content with a geolocation.
   $connection = \Drupal::database();
-  $query = $connection->select($taxonomy_field, 'node__field_table');
-  $query->join('node__field_geolocation', 'geolocation', 'geolocation.entity_id = node__field_table.entity_id');
-  $query->join('taxonomy_term_field_data', 'tname', 'tname.tid = node__field_table.' . $select_field);
-  $query->condition('tname.langcode', $language);
-  $query->fields('node__field_table', [$select_field]);
+  $query = $connection->select('node__'.$taxonomy_field, 'node_field_data');
+  $query->join('node__field_geolocation', 'geolocation', 'geolocation.entity_id = node_field_data.entity_id');
+  $query->join('taxonomy_term_field_data', 'tname', 'tname.tid = node_field_data.' . $select_field);
+  // Let's restore this condition once we have translated terms.
+  // TODO: also add condition that node must have translation.
+  // $query->condition('tname.langcode', $language);
+  $query->fields('node_field_data', [$select_field]);
   $query->fields('tname', ['name']);
   $result = $query->distinct()->execute();
   while ($row = $result->fetchAssoc()) {
@@ -152,11 +154,13 @@ function _get_active_terms($taxonomy_field, $select_field) {
 
   // Find taxonomy terms that link to media type content with a geolocation.
   $connection = \Drupal::database();
-  $query = $connection->select($taxonomy_field, 'media__field_table');
-  $query->join('media__field_geolocation', 'geolocation', 'geolocation.entity_id = media__field_table.entity_id');
-  $query->join('taxonomy_term_field_data', 'tname', 'tname.tid = media__field_table.' . $select_field);
-  $query->condition('tname.langcode', $language);
-  $query->fields('media__field_table', [$select_field]);
+  $query = $connection->select('media__'.$taxonomy_field, 'media_field_data');
+  $query->join('media__field_geolocation', 'geolocation', 'geolocation.entity_id = media_field_data.entity_id');
+  $query->join('taxonomy_term_field_data', 'tname', 'tname.tid = media_field_data.' . $select_field);
+  // Let's restore this filter once we have translated terms.
+  // TODO: also add condition that media entity must have translation.
+  // $query->condition('tname.langcode', $language);
+  $query->fields('media_field_data', [$select_field]);
   $query->fields('tname', ['name']);
   $result = $query->distinct()->execute();
   while ($row = $result->fetchAssoc()) {

--- a/public/modules/custom/helhist_map/src/MapService.php
+++ b/public/modules/custom/helhist_map/src/MapService.php
@@ -34,8 +34,11 @@ class MapService {
     if (!$map_layer_nodes || empty($map_layer_nodes)) {
       return $layers;
     }
+
+    $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
     
     foreach ($map_layer_nodes as $node) {
+      $node = \Drupal::service('entity.repository')->getTranslationFromContext($node, $language);
       $layer_title = $node->get('field_layer_title')->getString();
       $map_layer_api_endpoints_field = $node->get('field_map_api_endpoints');
 


### PR DESCRIPTION
- goto `/admin/content `and find the map layer "Kaupunginosat"
- change language to FI and make a SV translation
- clear caches
- in `/sv/kartta`, the label of the map layer should be translated

Bonus: fixes the keyword filter to only show options that return results
Todo: the filter doesn't have a condition that options/results must be in current language