### PR TITLE
Story/his 272 add article metatags to teaser

### DIFF
--- a/conf/cmi/core.entity_view_display.node.article.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.article.teaser.yml
@@ -39,7 +39,7 @@ content:
   content_moderation_control:
     settings: {  }
     third_party_settings: {  }
-    weight: -20
+    weight: 0
     region: content
   field_end_year:
     type: number_integer
@@ -48,7 +48,7 @@ content:
       thousand_separator: ''
       prefix_suffix: false
     third_party_settings: {  }
-    weight: 3
+    weight: 4
     region: content
   field_liftup_image:
     type: entity_reference_entity_view
@@ -57,7 +57,15 @@ content:
       view_mode: content_card
       link: false
     third_party_settings: {  }
-    weight: 0
+    weight: 1
+    region: content
+  field_neighbourhoods:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: 6
     region: content
   field_phenomena:
     type: entity_reference_label
@@ -65,7 +73,7 @@ content:
     settings:
       link: false
     third_party_settings: {  }
-    weight: 1
+    weight: 2
     region: content
   field_start_year:
     type: number_integer
@@ -74,7 +82,15 @@ content:
       thousand_separator: ''
       prefix_suffix: false
     third_party_settings: {  }
-    weight: 2
+    weight: 3
+    region: content
+  field_turning_points:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: 5
     region: content
 hidden:
   field_author: true
@@ -92,9 +108,7 @@ hidden:
   field_languages: true
   field_lead: true
   field_metatags: true
-  field_neighbourhoods: true
   field_reading_time: true
-  field_turning_points: true
   langcode: true
   links: true
   search_api_excerpt: true

--- a/conf/cmi/metatag.metatag_defaults.front.yml
+++ b/conf/cmi/metatag.metatag_defaults.front.yml
@@ -8,6 +8,6 @@ id: front
 label: 'Front page'
 tags:
   canonical_url: '[site:url]'
+  og_image_url: '[node:field_liftup_image:entity:field_media_image:og_image:url],[site:base-url]/themes/contrib/hdbt/src/images/og-global.png'
   shortlink: '[site:url]'
-  og_image: '[node:shareable-image]'
-  twitter_cards_image: '[node:shareable-image]'
+  twitter_cards_image: '[node:field_liftup_image:entity:field_media_image:og_image:url],[site:base-url]/themes/contrib/hdbt/src/images/og-global.png'

--- a/public/themes/custom/hdbt_subtheme/templates/content/node--article--teaser.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/content/node--article--teaser.html.twig
@@ -120,6 +120,22 @@
           </div>
         {% endif %}
 
+        {% if content.field_neighbourhoods|render %}
+          <div class="content-card__neighbourhoods content-card__metadata-item">
+            <span class="content-card__metadata-item__text">
+              {{ content.field_neighbourhoods }}
+            </span>
+          </div>
+        {% endif %}
+
+        {% if content.field_turning_points|render %}
+          <div class="content-card__turning_points content-card__metadata-item">
+            <span class="content-card__metadata-item__text">
+              {{ content.field_turning_points }}
+            </span>
+          </div>
+        {% endif %}
+
         {% if content.field_start_year|render %}
           <div class="content-card__year content-card__metadata-item">
             {% set start_year = (content.field_start_year[0]['#markup'] > 0) ? content.field_start_year[0]['#markup'] : content.field_start_year[0]['#markup']|abs ~ ' ' ~ 'BCE'|t %}
@@ -140,7 +156,7 @@
         {{ label }}
       </h3>
       {{ title_suffix }}
-      
+
       <span class="content-card__arrow{% if target_new %} is-outbound{% endif %}">
         {% include '@hdbt/misc/icon.twig' with {icon: 'arrow-right', label: 'Go to content'|t } %}
       </span>


### PR DESCRIPTION
make drush-cim
make drush-cr 

Adds neighbourhood and turning points metatags to article teaser display.
Adds correct metatags for og:image-url

Test by adding tags for metatag neighbourhood and turning points fields and confirm they  are rendered properly in the frontpage teaser view.