### PR TITLE
HIS-237: Better taxonomy tools

### DIFF
--- a/conf/cmi/language/fi/views.view.untranslated_taxonomy_terms.yml
+++ b/conf/cmi/language/fi/views.view.untranslated_taxonomy_terms.yml
@@ -1,0 +1,16 @@
+label: 'Käännä luokittelutermejä'
+display:
+  default:
+    display_options:
+      title: 'Käännä luokittelutermejä'
+      filters:
+        name:
+          expose:
+            label: 'Hae nimellä'
+        vid:
+          expose:
+            label: Sanasto
+  page_1:
+    display_options:
+      menu:
+        title: 'Käännä luokittelutermejä'

--- a/conf/cmi/views.view.untranslated_taxonomy_terms.yml
+++ b/conf/cmi/views.view.untranslated_taxonomy_terms.yml
@@ -127,7 +127,7 @@ display:
           click_sort_column: target_id
           type: entity_reference_label
           settings:
-            link: false
+            link: true
           group_column: target_id
           group_columns: {  }
           group_rows: true
@@ -248,7 +248,7 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: dropbutton
-          label: 'Translations link'
+          label: 'Translate link'
           exclude: false
           alter:
             alter_text: false
@@ -295,6 +295,177 @@ display:
             name: '0'
             vid: '0'
             entity_translations_field: '0'
+        vid_1:
+          id: vid_1
+          table: taxonomy_term_field_data
+          field: vid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: vid
+          plugin_id: field
+          label: 'Vocabulary ID'
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_entity_id
+          settings: {  }
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        merge_link:
+          id: merge_link
+          table: views
+          field: merge_link
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: custom
+          label: 'Link to merge'
+          exclude: true
+          alter:
+            alter_text: true
+            text: Merge
+            make_link: true
+            path: 'admin/structure/taxonomy/manage/{{ vid_1 }}/merge'
+            absolute: true
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+        dropbutton_1:
+          id: dropbutton_1
+          table: views
+          field: dropbutton
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: dropbutton
+          label: 'Merge link'
+          exclude: false
+          alter:
+            alter_text: false
+            text: Merge
+            make_link: false
+            path: '/admin/structure/taxonomy/manage/{{ vid }}/merge'
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          destination: false
+          fields:
+            merge_link: merge_link
+            name: '0'
+            vid: '0'
+            entity_translations_field: '0'
+            translation_link: '0'
+            dropbutton: '0'
+            vid_1: '0'
         operations:
           id: operations
           table: taxonomy_term_data
@@ -481,6 +652,52 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        name:
+          id: name
+          table: taxonomy_term_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: name
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: name_op
+            label: Search
+            description: ''
+            use_operator: false
+            operator: name_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: name
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              read_only: '0'
+              content_producer: '0'
+              editor: '0'
+              admin: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
         vid:
           id: vid
           table: taxonomy_term_field_data
@@ -526,6 +743,10 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: table
         options:
@@ -621,6 +842,17 @@ display:
         metatag_display_extender:
           metatags: {  }
           tokenize: false
+        matomo:
+          enabled: false
+          keyword_gets: ''
+          keyword_behavior: first
+          keyword_concat_separator: ' '
+          category_behavior: none
+          category_gets: ''
+          category_concat_separator: ' '
+          category_fallback: ''
+          category_facets: {  }
+          category_facets_concat_separator: ', '
       path: admin/structure/taxonomy/untranslated-taxonomy-terms
       menu:
         type: normal
@@ -629,7 +861,7 @@ display:
         weight: 0
         expanded: false
         menu_name: admin
-        parent: hdbt_admin_tools.overview
+        parent: hdbt_admin_tools.taxonomy
         context: '0'
     cache_metadata:
       max-age: -1

--- a/public/modules/custom/helhist_admin_forms/css/styles.css
+++ b/public/modules/custom/helhist_admin_forms/css/styles.css
@@ -1,0 +1,7 @@
+#taxonomy-merge-terms .fieldset__label {
+  margin-bottom: 0.25rem;
+}
+
+#taxonomy-merge-terms #edit-terms label {
+  font-size: 1rem !important;
+}

--- a/public/modules/custom/helhist_admin_forms/helhist_admin_forms.libraries.yml
+++ b/public/modules/custom/helhist_admin_forms/helhist_admin_forms.libraries.yml
@@ -1,5 +1,8 @@
 finna_import:
   version: 1.x
+  css:
+    theme:
+      css/styles.css: {}
   js:
     js/finna_import.js: {}
   dependencies:

--- a/public/modules/custom/helhist_admin_forms/helhist_admin_forms.module
+++ b/public/modules/custom/helhist_admin_forms/helhist_admin_forms.module
@@ -127,6 +127,13 @@ function helhist_admin_forms_form_alter(&$form, &$form_state, $form_id) {
       $form['#attached']['library'][] = 'helhist_admin_forms/finna_import';
 
       break;
+
+    case 'taxonomy_merge_terms':
+      $form['#attached']['library'][] = 'helhist_admin_forms/finna_import';
+      $form['terms']['#type'] = 'checkboxes';
+      asort($form['terms']['#options']);
+
+      break;
   }
 
   return $form;

--- a/public/modules/custom/helhist_admin_forms/js/finna_import.js
+++ b/public/modules/custom/helhist_admin_forms/js/finna_import.js
@@ -18,8 +18,7 @@
 
           $formats_field = [
             {
-              // uuid: '63DcPSsYfssc_2rLO90Cmlk-c4DwPmfe_Aj4iFdxcpM',
-              uuid: 'hYnvnamR6ag_AxPcntKd-XexOpwMkaLhAxui6lsUShU',
+              url: $.parseJSON($('#edit-field-formats').attr('data-select2-config')).ajax.url.replace("%3A", ":"),
               element: $('#edit-field-formats'),
               json_wrapper: 'formats',
               json_key: 'translated'
@@ -28,8 +27,7 @@
 
           $authors_field = [
             {
-              // uuid: 'nL39PHzAu3uXzCPe2BBSlw4VVVuZsLVS6RtbkaMLdS8',
-              uuid: 'o5vLXb8HgB7zYu_XHLPrCslmmt-Hnd87yCE1cOrRvsE',
+              url: $.parseJSON($('#edit-field-authors').attr('data-select2-config')).ajax.url.replace("%3A", ":"),
               element: $('#edit-field-authors'),
               json_wrapper: 'nonPresenterAuthors',
               json_key: 'name'
@@ -38,8 +36,7 @@
 
           $copyrights_field = [
             {
-              // uuid: 'HSgHktR7ejpMhZd1Y-atx9Axw7SuNtwq0FT_sAh8smU',
-              uuid: 'uLeAPTPSYBImqlrCXa80txmYaj1B7rrTbPvmvunHjxE',
+              url: $.parseJSON($('#edit-field-copyrights').attr('data-select2-config')).ajax.url.replace("%3A", ":"),
               element: $('#edit-field-copyrights'),
               json_wrapper: 'imageRights',
               json_key: 'copyright'
@@ -48,8 +45,7 @@
 
           $buildings_field = [
             {
-              // uuid: '8S0fSi9mz_jgq_PU9xvyDN2ir3lHAnsjmz7_9rnCThY',
-              uuid: '9ohEZZrClEf1sGsxVQvK0ye9W9HKlh0k6ZuNhZyRi5o',
+              url: $.parseJSON($('#edit-field-buildings').attr('data-select2-config')).ajax.url.replace("%3A", ":"),
               element: $('#edit-field-buildings'),
               json_wrapper: 'buildings',
               json_key: 'translated'
@@ -68,7 +64,7 @@
                 text: element[field.json_key]
               };
               // Programmatically get Select2 results
-              $.getJSON('/' + $langcode + '/select2_autocomplete/taxonomy_term/default:taxonomy_term/' + field.uuid + '?term=' + option_data.text + '&_type=query&q=' + option_data.text, function(data) {
+              $.getJSON(field.url + '?term=' + option_data.text + '&_type=query&q=' + option_data.text, function(data) {
                 if (data['results'].length > 0 && data['results'][0]['text'] === option_data.text) {
                   // Match found, use existing term ID for option
                   option_data.id = data['results'][0]['id'];


### PR DESCRIPTION
# [HIS-237](https://helsinkisolutionoffice.atlassian.net/browse/HIS-237)
Translating and merging taxonomy terms is hard.

## What was done
* `/admin/structure/taxonomy/untranslated-taxonomy-terms` has been translated, added text search and link to merge interface.
* `/admin/structure/taxonomy/manage/keywords/merge` changed from very small multiselect to checkboxes.
* finna-import.js fixed to find field select2 UUID dynamically.

## How to install

* make drush-deploy

## How to test
* [ ] Check that `/admin/structure/taxonomy/untranslated-taxonomy-terms` looks neat
* [ ] Check that `/admin/structure/taxonomy/manage/keywords/merge` looks neat
* [ ] Check that finna.fi import works, for example with `museovirasto.915C2FC0291B3D829DB3DCD59922C55E`

## Designers review

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


[HIS-237]: https://helsinkisolutionoffice.atlassian.net/browse/HIS-237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ