### PR TITLE
HIS-303: Fix matomo analytics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -42,6 +42,9 @@
 *.xml     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.yml     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 
+# PHPStan's baseline uses tabs instead of spaces.
+core/.phpstan-baseline.php text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tabwidth=2 diff=php linguist-language=php
+
 # Define binary file attributes.
 # - Do not treat them as text.
 # - Include binary diff in patches instead of "binary files differ."

--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,11 @@ vendor
 helfi-test-automation-python/
 public/sites/simpletest/
 
-# Ignore the folder created by PhpStorm
+# Ignore the folders created by IDE
 .idea/*
+.vscode/
+
+# Ignore local settings
 public/sites/default/local.settings.php
 
 *.sql

--- a/composer.json
+++ b/composer.json
@@ -122,6 +122,9 @@
             "drupal/leaflet": {
                 "Add entity id to marker options": "custom-patches/leaflet_add_entity_id_to_marker_options.patch"
             },
+            "drupal/matomo": {
+                "HIS-303 Fix Digia Iiris tracker url": "custom-patches/HIS-303-matomo-digia-tracker-url.patch"
+            },
             "drupal/search_api": {
                 "Properties via entity reference fields are not translated (https://www.drupal.org/project/search_api/issues/3039139#comment-13016070)": "https://www.drupal.org/files/issues/2019-03-11/3039139-3.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7cadbcda72618076ae393becdc1c1630",
+    "content-hash": "fce5a8ccbf193a256f1a7dc44fe61d3a",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -5853,17 +5853,17 @@
         },
         {
             "name": "drupal/matomo",
-            "version": "1.23.0",
+            "version": "1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/matomo.git",
-                "reference": "8.x-1.23"
+                "reference": "8.x-1.25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/matomo-8.x-1.23.zip",
-                "reference": "8.x-1.23",
-                "shasum": "c2dbf12878388c5859e64f1e74a9ca5110d1623f"
+                "url": "https://ftp.drupal.org/files/projects/matomo-8.x-1.25.zip",
+                "reference": "8.x-1.25",
+                "shasum": "5e65764f4499061fa33cb5c46afcc26a85b8725e"
             },
             "require": {
                 "drupal/core": "^9.0 || ^10"
@@ -5879,8 +5879,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.23",
-                    "datestamp": "1700936102",
+                    "version": "8.x-1.25",
+                    "datestamp": "1738948462",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -5893,11 +5893,11 @@
             ],
             "authors": [
                 {
-                    "name": "C-Logemann",
+                    "name": "c-logemann",
                     "homepage": "https://www.drupal.org/user/218368"
                 },
                 {
-                    "name": "Grimreaper",
+                    "name": "grimreaper",
                     "homepage": "https://www.drupal.org/user/2388214"
                 },
                 {
@@ -19084,7 +19084,7 @@
     },
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/conf/cmi/matomo.settings.yml
+++ b/conf/cmi/matomo.settings.yml
@@ -6,13 +6,7 @@ url_https: 'https://webanalytics.digiaiiris.com/js/'
 domain_mode: 0
 visibility:
   request_path_mode: 0
-  request_path_pages: |-
-    /admin
-    /admin/*
-    /batch
-    /node/add*
-    /node/*/*
-    /user/*/*
+  request_path_pages: "/admin\r\n/admin/*\r\n/batch\r\n/node/add*\r\n/node/*/*\r\n/user/*/*"
   user_role_mode: 0
   user_role_roles: {  }
   user_account_mode: 1
@@ -28,7 +22,32 @@ privacy:
   donottrack: true
   disablecookies: false
 custom:
-  variable: {  }
+  variable:
+    1:
+      slot: 1
+      name: ''
+      value: ''
+      scope: visit
+    2:
+      slot: 2
+      name: ''
+      value: ''
+      scope: visit
+    3:
+      slot: 3
+      name: ''
+      value: ''
+      scope: visit
+    4:
+      slot: 4
+      name: ''
+      value: ''
+      scope: visit
+    5:
+      slot: 5
+      name: ''
+      value: ''
+      scope: visit
 codesnippet:
   before: ''
   after: ''

--- a/custom-patches/HIS-303-matomo-digia-tracker-url.patch
+++ b/custom-patches/HIS-303-matomo-digia-tracker-url.patch
@@ -1,0 +1,26 @@
+diff --git a/matomo.module b/matomo.module
+index 08daac0..7a41988 100644
+--- a/matomo.module
++++ b/matomo.module
+@@ -228,7 +228,7 @@ function matomo_page_attachments(array &$page) {
+     $script .= '(function(){';
+     $script .= 'var u=(("https:" == document.location.protocol) ? "' . UrlHelper::filterBadProtocol($url_https) . '" : "' . UrlHelper::filterBadProtocol($url_http) . '");';
+     $script .= '_paq.push(["setSiteId", ' . Json::encode($id) . ']);';
+-    $script .= '_paq.push(["setTrackerUrl", u+"matomo.php"]);';
++    $script .= '_paq.push(["setTrackerUrl", u+"tracker.php"]);';
+ 
+     // Track logged in users across all devices.
+     if ($config->get('track.userid') && $account->isAuthenticated()) {
+diff --git a/src/Form/MatomoAdminSettingsForm.php b/src/Form/MatomoAdminSettingsForm.php
+index aba9342..100f614 100644
+--- a/src/Form/MatomoAdminSettingsForm.php
++++ b/src/Form/MatomoAdminSettingsForm.php
+@@ -857,7 +857,7 @@ class MatomoAdminSettingsForm extends ConfigFormBase {
+       $url .= '/';
+       $form_state->setValueForElement($form['general'][$urlFormKey], $url);
+     }
+-    $url = $url . 'matomo.php';
++    $url = $url . 'tracker.php';
+     try {
+       $result = $this->httpClient->request('GET', $url);
+       if ($result->getStatusCode() != Response::HTTP_OK) {


### PR DESCRIPTION
# [HIS-303](https://helsinkisolutionoffice.atlassian.net/browse/HIS-303)

https://digiaiiris.com/analytics has not been recording traffic since 21.2.2025. This PR attempts to fix this issue.

## What was done
* Added patch for matomo module to use the Digia Iiris tracker script
  * The [Matomo configurations](https://digiaiiris.com/analytics?relayparams=%2Findex.php%3Fmodule%3DCoreAdminHome%26action%3DtrackingCodeGenerator%26idSite%3D903%26period%3Dday%26date%3D2025-02-17) show the `setTrackerUrl` should be `tracker.php`
* Updated matomo module to a secure version
* Minor git config updates

## How to test
In production (or a branch without this fix), save the matomo config form `/admin/config/system/matomo` and you should see following error message 
```
The validation of "http://webanalytics.digiaiiris.com/js/matomo.php" failed with an 
exception "Client error: `GET http://webanalytics.digiaiiris.com/js/matomo.php`
resulted in a `404 Not Found
```

With this fix saving the config form `/admin/config/system/matomo` should not yield error.

Browsing the site, inspect with network tab there are no errors from from matomo tracker.

Deploying this to production should record traffic from the site to https://digiaiiris.com/analytics.

## Notes on the solution

This was solely my guess to fix this issue, I have not had confirmation from Digia Iiris if the tracker URL has changed or why analytics had stopped working after 21.1.2025

[HIS-303]: https://helsinkisolutionoffice.atlassian.net/browse/HIS-303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ