### PR TITLE
HIS-302: Fix missing img style on carousels

### DIFF
--- a/public/themes/custom/hdbt_subtheme/templates/paragraphs/paragraph--gallery.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/paragraphs/paragraph--gallery.html.twig
@@ -71,7 +71,7 @@
               {% set alt = false %}
             {% endif %}
             <li{{ gallery_thumbnails_item }}>
-              {{ drupal_image(image.uri.value, 'gallery_thumbnail', { alt: alt }, responsive=true) }}
+              {{ drupal_image(image.uri.value, 'thumbnail', { alt: alt }) }}
             </li>
           {% endfor %}
         </ul>


### PR DESCRIPTION
One missing disappeared image style replaced, suppressing number of errors from logs.