### PR TITLE
HIS-292: Image media page enhancements

### DIFF
--- a/public/modules/custom/helhist_media_usage/templates/media-usage-block.html.twig
+++ b/public/modules/custom/helhist_media_usage/templates/media-usage-block.html.twig
@@ -1,6 +1,6 @@
 {% if content %}
   <div class="media__usage">
-    <h3 class="label">{{ 'Used in articles'|t({}, {'context': 'Content'}) }}</h3>
+    <h2 class="label">{{ 'Used in articles'|t({}, {'context': 'Content'}) }}</h3>
     {% for nid in content %}
       {{ drupal_entity('node', nid, 'listing_item') }}
     {% endfor %}

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -94,6 +94,8 @@ function hdbt_subtheme_preprocess_node(&$variables) {
 function hdbt_subtheme_preprocess_field(&$variables, $hook) {
   $field_name = $variables['element']['#field_name'];
 
+  $variables['site_search_page_url'] = _get_search_page_url();
+
   // Provide term's machine name as variable (prefer English)
   if ($field_name == 'field_formats') {
     $field_items = $variables['element']['#items']->getValue();
@@ -255,6 +257,26 @@ function _get_top_level_menu_parent_title_by_nid($node_id) {
   }
 
   return $parent_title;
+}
+
+/**
+ * Get the site's global search page URL.
+ *
+ * Search page is implemented as node/114. This helper function is used to get
+ * the URL for the search page to not duplicate the node id template files.
+ *
+ * @return string
+ *   The search page URL.
+ */
+function _get_search_page_url($nid = 114) {
+  return \Drupal::service('url_generator')->generateFromRoute('entity.node.canonical', ['node' => $nid]);
+}
+
+/**
+ * Implements template_preprocess_paragraph().
+ */
+function hdbt_subtheme_preprocess_media(&$variables) {
+  $variables['site_search_page_url'] = _get_search_page_url();
 }
 
 /**

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -8,6 +8,19 @@
 use Drupal\node\Entity\Node;
 
 /**
+ * Get the site's global search page URL.
+ *
+ * Search page is implemented as node/114. This helper function is used to get
+ * the URL for the search page to not duplicate the node id template files.
+ *
+ * @return string
+ *   The search page URL.
+ */
+function hdbt_subtheme_get_search_page_url($nid = 114) {
+  return \Drupal::service('url_generator')->generateFromRoute('entity.node.canonical', ['node' => $nid]);
+}
+
+/**
  * Helper function to get the icons path.
  *
  * @return string|null
@@ -94,7 +107,7 @@ function hdbt_subtheme_preprocess_node(&$variables) {
 function hdbt_subtheme_preprocess_field(&$variables, $hook) {
   $field_name = $variables['element']['#field_name'];
 
-  $variables['site_search_page_url'] = _get_search_page_url();
+  $variables['site_search_page_url'] = hdbt_subtheme_get_search_page_url();
 
   // Provide term's machine name as variable (prefer English)
   if ($field_name == 'field_formats') {
@@ -260,23 +273,10 @@ function _get_top_level_menu_parent_title_by_nid($node_id) {
 }
 
 /**
- * Get the site's global search page URL.
- *
- * Search page is implemented as node/114. This helper function is used to get
- * the URL for the search page to not duplicate the node id template files.
- *
- * @return string
- *   The search page URL.
- */
-function _get_search_page_url($nid = 114) {
-  return \Drupal::service('url_generator')->generateFromRoute('entity.node.canonical', ['node' => $nid]);
-}
-
-/**
  * Implements template_preprocess_paragraph().
  */
 function hdbt_subtheme_preprocess_media(&$variables) {
-  $variables['site_search_page_url'] = _get_search_page_url();
+  $variables['site_search_page_url'] = hdbt_subtheme_get_search_page_url();
 }
 
 /**

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -71,14 +71,13 @@ function hdbt_subtheme_preprocess_html(&$variables) {
   }
 }
 
+/**
+ * Implements template_preprocess_region().
+ */
 function hdbt_subtheme_preprocess_region(&$variables) {
-  $variables['is_frontpage'] = false;
-  $variables['has_hero'] = false;
-  $variables['hide_koro'] = false;
-
-  if (\Drupal::service('path.matcher')->isFrontPage()) {
-    $variables['is_frontpage'] = true;
-  }
+  $variables['is_frontpage'] = \Drupal::service('path.matcher')->isFrontPage();
+  $variables['has_hero'] = FALSE;
+  $variables['hide_koro'] = FALSE;
 
   $node = \Drupal::routeMatch()->getParameter('node');
   if ($node instanceof Node) {
@@ -86,7 +85,7 @@ function hdbt_subtheme_preprocess_region(&$variables) {
       $variables['has_hero'] = intval($node->get('field_has_hero')->getString());
     }
     if ($node->bundle() == 'map_page') {
-      $variables['hide_koro'] = true;
+      $variables['hide_koro'] = TRUE;
     }
   }
 }

--- a/public/themes/custom/hdbt_subtheme/templates/field/field--hdbt-taxonomy--full.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/field/field--hdbt-taxonomy--full.html.twig
@@ -52,8 +52,7 @@
     <h3{{ title_attributes.addClass(title_classes) }} id={{ field_name }}>{{ label|t({}, {'context': 'Content'}) }}</h3>
     <div class="hdbt_taxonomy" aria-labelledby={{ field_name }}>
       {% for item in items %}
-        {# Node 114 is search page. This might be done better. #}
-        <a href="{{ path('entity.node.canonical', {'node': '114'}) }}?s={{ item.content }}"><span>{{ item.content }}</span></a>
+        <a href="{{ site_search_page_url }}?s={{ item.content }}"><span>{{ item.content }}</span></a>
       {% endfor %}
     </div>
   </div>

--- a/public/themes/custom/hdbt_subtheme/templates/media/media--image--full.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/media/media--image--full.html.twig
@@ -128,8 +128,7 @@
                 <div class="hdbt_taxonomy__wrapper">
                   <h3 class="label" id="field_photographer">{{ content.field_photographer['#title'] }}</h3>
                   <div class="hdbt_taxonomy" aria-labelledby="field_photographer">
-                    {# Node 114 is search page. This might be done better. #}
-                    <a href="{{ path('entity.node.canonical', {'node': '114'}) }}?s={{ content.field_photographer.0 }}"><span>{{ content.field_photographer.0 }}</span></a>
+                    <a href="{{ site_search_page_url }}?s={{ content.field_photographer.0 }}"><span>{{ content.field_photographer.0 }}</span></a>
                   </div>
                 </div>
               </div>
@@ -158,8 +157,7 @@
               <div class="hdbt_taxonomy__wrapper">
                 <h3 class="label" id="field_group_year">{{ 'Period'|t({}, {'context': 'Content'}) }}</h3>
                   <div class="hdbt_taxonomy" aria-labelledby="field_group_year">
-                    {# Node 114 is search page. This might be done better. #}
-                    <a href="{{ path('entity.node.canonical', {'node': '114'}) }}?s={{ period }}"><span>{{ period }}</span></a>
+                    <a href="{{ site_search_page_url }}?s={{ period }}"><span>{{ period }}</span></a>
                   </div>
                 </div>
               </div>

--- a/public/themes/custom/hdbt_subtheme/templates/media/media--image--full.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/media/media--image--full.html.twig
@@ -134,17 +134,19 @@
               </div>
             {% endif %}
 
-            {% if content.field_phenomena|render %}
-              <div class="{{ media.bundle()|clean_class }}__phenomena">
-                {{ content.field_phenomena }}
-              </div>
-            {% endif %}
+            {# The field names to print as tag-like search links #}
+            {% set fields_set_1 = [
+              'field_phenomena',
+              'field_neighbourhoods',
+            ] %}
 
-            {% if content.field_neighbourhoods|render %}
-              <div class="{{ media.bundle()|clean_class }}__neighbourhoods">
-                {{ content.field_neighbourhoods }}
-              </div>
-            {% endif %}
+            {% for field in fields_set_1 %}
+              {% if content[field]|render %}
+                <div class="{{ media.bundle()|clean_class }}__{{ field }}">
+                  {{ content[field] }}
+                </div>
+              {% endif %}
+            {% endfor %}
 
             {% if content.field_start_year|render %}
               <div class="{{ media.bundle()|clean_class }}__group_year">
@@ -177,47 +179,25 @@
               </div>
             {% endif %}
 
-            {% if content.field_formats|render %}
-              <div class="{{ media.bundle()|clean_class }}__formats">
-                {{ content.field_formats }}
-              </div>
-            {% endif %}
+            {# The field names to print as tag-like search links #}
+            {% set fields_set_2 = [
+              'field_formats',
+              'field_keywords',
+              'field_authors',
+              'field_copyrights',
+              'field_languages',
+              'field_buildings',
+              'field_buildings_info'
+            ] %}
 
-            {% if content.field_keywords|render %}
-              <div class="{{ media.bundle()|clean_class }}__formats">
-                {{ content.field_keywords }}
-              </div>
-            {% endif %}
+            {% for field in fields_set_2 %}
+              {% if content[field]|render %}
+                <div class="{{ media.bundle()|clean_class }}__{{ field }}">
+                  {{ content[field] }}
+                </div>
+              {% endif %}
+            {% endfor %}
 
-            {% if content.field_authors|render %}
-              <div class="{{ media.bundle()|clean_class }}__authors">
-                {{ content.field_authors }}
-              </div>
-            {% endif %}
-
-            {% if content.field_copyrights|render %}
-              <div class="{{ media.bundle()|clean_class }}__copyrights">
-                {{ content.field_copyrights }}
-              </div>
-            {% endif %}
-
-            {% if content.field_languages|render %}
-              <div class="{{ media.bundle()|clean_class }}__languages">
-                {{ content.field_languages }}
-              </div>
-            {% endif %}
-
-            {% if content.field_buildings|render %}
-              <div class="{{ media.bundle()|clean_class }}__buildings">
-                {{ content.field_buildings }}
-              </div>
-            {% endif %}
-
-            {% if content.field_buildings_info|render %}
-              <div class="{{ media.bundle()|clean_class }}__buildings_info">
-                {{ content.field_buildings_info }}
-              </div>
-            {% endif %}
           </div>
         {% endblock component_content %}
       {% endembed %}

--- a/public/themes/custom/hdbt_subtheme/templates/media/media--image--full.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/media/media--image--full.html.twig
@@ -35,6 +35,11 @@
     view_mode ? 'media--view-mode-' ~ view_mode|clean_class,
   ]
 %}
+
+{% if content.field_finna_id[0]['#context']['value'] is defined %}
+  {% set finna_url = 'https://finna.fi/Record/' ~ content.field_finna_id[0]['#context']['value'] %}
+{% endif %}
+
 <article{{ attributes.addClass(classes) }}>
   <div class="before-content">
     <div class="page-title">
@@ -73,7 +78,9 @@
           <div class="{{ left_column_classes|join(' ') }}">
             {% if content.field_media_image|render %}
               <div class="{{ media.bundle()|clean_class }}__media_image">
-                {{ content.field_media_image }}
+                <a href="{{ finna_url }}" target="_blank" title="{{ 'Open image to new window to Finna.fi'|t }}">
+                  {{ content.field_media_image }}
+                </a>
               </div>
             {% endif %}
             {% if content.field_image_caption|render %}
@@ -119,7 +126,7 @@
             {% if content.field_photographer|render %}
               <div class="{{ media.bundle()|clean_class }}__photographer">
                 <div class="hdbt_taxonomy__wrapper">
-                  <h3 class="label" id="field_photographer">{{ content.field_photographer['#title']|t({}, {'context': 'Content'}) }}</h3>
+                  <h3 class="label" id="field_photographer">{{ content.field_photographer['#title'] }}</h3>
                   <div class="hdbt_taxonomy" aria-labelledby="field_photographer">
                     {# Node 114 is search page. This might be done better. #}
                     <a href="{{ path('entity.node.canonical', {'node': '114'}) }}?s={{ content.field_photographer.0 }}"><span>{{ content.field_photographer.0 }}</span></a>
@@ -160,13 +167,13 @@
           </div>
 
           <div class="{{ right_column_classes|join(' ') }}">
-            {% if content.field_finna_id|render %}
+            {% if finna_url is defined %}
               <div class="{{ media.bundle()|clean_class }}__finna_id">
-                <h3 class="label">{{ content.field_finna_id['#title']|t({}, {'context': 'Content'}) }}</h3>
+                <h3 class="label">{{ content.field_finna_id['#title'] }}</h3>
                 {% include '@hdbt/navigation/link-button.html.twig' with {
                   type: 'primary',
                   label: 'Open in new window'|t({}, {'context': 'Button'}),
-                  url: 'https://finna.fi/Record/' ~ content.field_finna_id[0]['#context']['value'],
+                  url: finna_url,
                   open_in_a_new_window: true,
                 } %}
               </div>
@@ -175,6 +182,12 @@
             {% if content.field_formats|render %}
               <div class="{{ media.bundle()|clean_class }}__formats">
                 {{ content.field_formats }}
+              </div>
+            {% endif %}
+
+            {% if content.field_keywords|render %}
+              <div class="{{ media.bundle()|clean_class }}__formats">
+                {{ content.field_keywords }}
               </div>
             {% endif %}
 


### PR DESCRIPTION
# https://helsinkisolutionoffice.atlassian.net/browse/HIS-292

## What was done

* Link the image media image file to Finna service
* Add tags and link them to search
* Accessibility / heading semantics fix on media image pages
* Refactor a bit
  * Avoid node/114 duplication on template files by getting it from a function
  * Remove antipattern of putting variables into `t()` in twig files
  * Less code duplication, do repetitive rendering via loops

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/HIS-292`
  * `make fresh`

## How to test
See any image media page

See nothing else got broken

