### PR TITLE
HIS-321: Require and enable redis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "drupal/migrate_tools": "^6.0",
         "drupal/optional_end_date": "^1.3",
         "drupal/rabbit_hole": "^1.0@beta",
+        "drupal/redis": "^1.9",
         "drupal/search_api_autocomplete": "^1.8",
         "drupal/search_api_location": "^1.0@alpha",
         "drupal/search_api_sorts": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9a0f52230079c77574f19b80712f02f0",
+    "content-hash": "e418ab78f5728aa7ecee6f0a15a2dae3",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -7807,6 +7807,72 @@
             "homepage": "https://www.drupal.org/project/redirect",
             "support": {
                 "source": "https://git.drupalcode.org/project/redirect"
+            }
+        },
+        {
+            "name": "drupal/redis",
+            "version": "1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/redis.git",
+                "reference": "8.x-1.9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/redis-8.x-1.9.zip",
+                "reference": "8.x-1.9",
+                "shasum": "77e2e8ddb95be08f3fe9f74182c7ff0476e15674"
+            },
+            "require": {
+                "drupal/core": "^9.3 || ^10 || ^11"
+            },
+            "suggest": {
+                "ext-redis": "Required to use the PhpRedis as redis driver (^4.0|^5.0).",
+                "ext-relay": "Required to use the Relay as Redis driver (^0.5|^1.0).",
+                "predis/predis": "Required to use the Predis as redis driver (^1.1|^2.0)."
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.9",
+                    "datestamp": "1737932099",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Drupal\\redis\\": "src"
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "berdir",
+                    "homepage": "https://www.drupal.org/user/214652"
+                },
+                {
+                    "name": "greg.1.anderson",
+                    "homepage": "https://www.drupal.org/user/438598"
+                },
+                {
+                    "name": "kporras07",
+                    "homepage": "https://www.drupal.org/user/1349780"
+                },
+                {
+                    "name": "pounard",
+                    "homepage": "https://www.drupal.org/user/240164"
+                }
+            ],
+            "description": "Integration of Drupal with the Redis key-value store.",
+            "homepage": "https://www.drupal.org/project/redis",
+            "support": {
+                "source": "https://git.drupalcode.org/project/redis"
             }
         },
         {

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -175,6 +175,7 @@ module:
   readonly_field_widget: 0
   real_aes: 0
   redirect: 0
+  redis: 0
   responsive_image: 0
   rh_node: 0
   role_delegation: 0


### PR DESCRIPTION
# https://helsinkisolutionoffice.atlassian.net/browse/HIS-321

Make site perform better by enabling Redis cache layer.


## What was done
Required and enabled [redis](https://drupal.org/project/redis) module. All variables seemed to already be in place

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/HIS-321`
  * `make fresh`
* Run `make drush-cr`

## How to test


* See site connect to Redis at `/en/admin/reports/redis`
* See things still work, and faster