### PR TITLE
HIS-324: Update kore search hardcoded year filter max values

### DIFF
--- a/conf/cmi/views.view.kore_search.yml
+++ b/conf/cmi/views.view.kore_search.yml
@@ -229,7 +229,7 @@ display:
                   collapsible_disable_automatic_open: false
                   is_secondary: false
                 min: '1550'
-                max: '2024'
+                max: '2025'
                 step: '1'
                 animate: '0'
                 animate_ms: '0'
@@ -242,7 +242,7 @@ display:
                   collapsible_disable_automatic_open: false
                   is_secondary: false
                 min: '1550'
-                max: '2024'
+                max: '2025'
                 step: '1'
                 animate: '0'
                 animate_ms: '0'
@@ -548,7 +548,7 @@ display:
           value:
             min: ''
             max: ''
-            value: '2024'
+            value: '2025'
           group: 3
           exposed: true
           expose:
@@ -573,7 +573,7 @@ display:
               super_administrator: '0'
             min_placeholder: ''
             max_placeholder: ''
-            placeholder: '2024'
+            placeholder: '2025'
           is_grouped: false
           group_info:
             label: ''


### PR DESCRIPTION
# [HIS-324](https://helsinkisolutionoffice.atlassian.net/browse/HIS-324)

Fixing the hardcoded year filters for `/koulurekisteri` search, quick and dirty fix which I already updated to production views configurations manually. Didn't start making it dynamic, the whole search could/should maybe be reimplemented away from views..

[HIS-324]: https://helsinkisolutionoffice.atlassian.net/browse/HIS-324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ