### PR TITLE
HIS-329: Disable survey block

### DIFF
--- a/conf/cmi/block.block.surveys.yml
+++ b/conf/cmi/block.block.surveys.yml
@@ -1,6 +1,6 @@
 uuid: f5d30dcc-c6ed-4376-8d55-90d9a7f81291
 langcode: en
-status: true
+status: false
 dependencies:
   module:
     - helfi_etusivu_entities


### PR DESCRIPTION
https://helsinkisolutionoffice.atlassian.net/browse/HIS-329

Block was disabled from production 19.9.2025 to avoid the the survey pop-up with link to closed survey from appearing on the site.