### PR TITLE
HIS-210: A11y - image/link texts for screenreaders

### DIFF
--- a/public/themes/custom/hdbt_subtheme/templates/content/node--article--listing-item.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/content/node--article--listing-item.html.twig
@@ -93,7 +93,7 @@
 <article{{ attributes.addClass(classes) }}>
 
   <a href="{{ url }}" class="content-card__link" rel="bookmark">
-    <div class="content-card__image">
+    <div class="content-card__image" aria-hidden="true">
       {% if image.0 %}
         {{ image }}
       {% else %}

--- a/public/themes/custom/hdbt_subtheme/templates/content/node--view--listings--sub-listing-block.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/content/node--view--listings--sub-listing-block.html.twig
@@ -100,7 +100,7 @@
 <article{{ attributes.addClass(classes) }}>
 
   <a href="{{ url }}" class="content-card__link" rel="bookmark">
-    <div class="content-card__image">
+    <div class="content-card__image" aria-hidden="true">
       {% if image.0 %}
         {{ image }}
       {% else %}

--- a/public/themes/custom/hdbt_subtheme/templates/media/media--image--full.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/media/media--image--full.html.twig
@@ -178,7 +178,7 @@
                   type: 'primary',
                   label: 'Open in new window'|t({}, {'context': 'Button'}),
                   url: finna_url,
-                  open_in_a_new_window: true,
+                  open_in_a_new_window: false,
                 } %}
               </div>
             {% endif %}

--- a/public/themes/custom/hdbt_subtheme/templates/paragraphs/paragraph--image.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/paragraphs/paragraph--image.html.twig
@@ -101,7 +101,7 @@
               {# Link image to media entity page #}
               <div class="media--image__content__image">
                 <a href="{{ path('entity.media.canonical', { 'media': media.id }) }}">
-                  {{ drupal_image(image['#uri'], 'orig_927w_free', {alt: image['#attributes']['alt']} ) }}
+                  {{ drupal_image(image['#uri'], 'orig_927w_free', {alt: media.label} ) }}
                 </a>
               </div>
               <div class="media--image__content__info">
@@ -145,7 +145,7 @@
           </div>
           <div class="media--image__content__info">
             {% if caption %}
-              <div class="media--image__content__caption">
+              <div class="media--image__content__caption" aria-hidden="true">
                 {{ caption }}
               </div>
             {% endif %}


### PR DESCRIPTION
# [HIS-210](https://helsinkisolutionoffice.atlassian.net/browse/HIS-210)

Fixing more a11y findings by PO, less verbose announcing of links, avoiding duplicate reading of image alt/texts.

Not opening links to new tab which trigger a11y warning

[HIS-210]: https://helsinkisolutionoffice.atlassian.net/browse/HIS-210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ