### PR TITLE
HIS-333: Fix phpcs and phpstan issues

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -4,14 +4,11 @@
   <exclude-pattern>*.css</exclude-pattern>
   <exclude-pattern>*.js</exclude-pattern>
   <exclude-pattern>*/node_modules/*</exclude-pattern>
-  <exclude-pattern>*/helhist_map/src/MapService.php</exclude-pattern>
-  <exclude-pattern>*/modules/custom/helhist_search/*</exclude-pattern>
-  <exclude-pattern>*/helhist_kore/*</exclude-pattern>
 
-  <!-- rule ref="Drupal" /-->
-  <rule ref="DrupalPractice">
-    <exclude name="DrupalPractice.General.OptionsT.TforValue" />
-    <exclude name="DrupalPractice.Objects.UnusedPrivateMethod.UnusedMethod" />
-  </rule>
-  <!-- rule ref="Generic.PHP.RequireStrictTypes" /-->
+  <!-- Ignore graphql_search_api, it will be removed via HIS-330 -->
+  <exclude-pattern>*/graphql_search_api/*</exclude-pattern>
+
+  <rule ref="Drupal" />
+  <rule ref="DrupalPractice" />
+  <rule ref="Generic.PHP.RequireStrictTypes" />
 </ruleset>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,10 +6,12 @@ parameters:
       - theme
   paths:
     - ./public/modules/custom/
+    - ./public/themes/custom/
   excludePaths:
     - vendor
     - */node_modules/*
     - ./public/modules/custom/graphql_search_api
+    - ./public/themes/custom/hdbt_subtheme/dist
   level: 3
   checkMissingIterableValueType: false
   treatPhpDocTypesAsCertain: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,10 +5,11 @@ parameters:
       - install
       - theme
   paths:
-    - ./public/modules/custom/helhist_tokens
+    - ./public/modules/custom/
   excludePaths:
     - vendor
     - */node_modules/*
+    - ./public/modules/custom/graphql_search_api
   level: 3
   checkMissingIterableValueType: false
   treatPhpDocTypesAsCertain: false

--- a/public/modules/custom/helhist_admin_forms/helhist_admin_forms.module
+++ b/public/modules/custom/helhist_admin_forms/helhist_admin_forms.module
@@ -5,9 +5,11 @@
  * Contains helhist_admin_forms.module.
  */
 
-use Drupal\Core\Routing\RouteMatchInterface;
+declare(strict_types=1);
+
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\InvokeCommand;
+use Drupal\Core\Routing\RouteMatchInterface;
 
 /**
  * Implements hook_help().
@@ -33,7 +35,7 @@ function helhist_admin_forms_form_node_form_alter(&$form, &$form_state, $form_id
     'node_article_edit_form',
     'node_article_form',
     'node_listing_page_edit_form',
-    'node_listing_page_form'
+    'node_listing_page_form',
   ])) {
     // Control Hero paragraph visibility via checkbox states.
     $form['field_hero']['#states'] = [
@@ -42,10 +44,10 @@ function helhist_admin_forms_form_node_form_alter(&$form, &$form_state, $form_id
       ],
     ];
   }
-  
+
   if (in_array($form_id, [
     'node_listing_page_edit_form',
-    'node_listing_page_form'
+    'node_listing_page_form',
   ])) {
     // Control Phenomena field visibility via Listing type selection.
     $form['field_phenomena']['#states'] = [
@@ -92,7 +94,7 @@ function helhist_admin_forms_form_alter(&$form, &$form_state, $form_id) {
           'event' => 'change',
         ],
         // Default to checked if saved year is negative.
-        '#default_value' => ($form['field_start_year']['widget'][0]['value']['#default_value'] < 0) ? TRUE : FALSE
+        '#default_value' => ($form['field_start_year']['widget'][0]['value']['#default_value'] < 0) ? TRUE : FALSE,
       ];
 
       $form['field_start_year']['widget'][0]['value']['#ajax'] = [
@@ -104,7 +106,7 @@ function helhist_admin_forms_form_alter(&$form, &$form_state, $form_id) {
         '#type' => 'checkbox',
         '#title' => t('Period'),
         // Default to checked if years are different.
-        '#default_value' => ($form['field_start_year']['widget'][0]['value']['#default_value'] != $form['field_end_year']['widget'][0]['value']['#default_value']) ? TRUE : FALSE
+        '#default_value' => ($form['field_start_year']['widget'][0]['value']['#default_value'] != $form['field_end_year']['widget'][0]['value']['#default_value']) ? TRUE : FALSE,
       ];
 
       $form['field_end_year']['#states'] = [
@@ -121,7 +123,7 @@ function helhist_admin_forms_form_alter(&$form, &$form_state, $form_id) {
           'event' => 'change',
         ],
         // Default to checked if saved year is negative.
-        '#default_value' => ($form['field_end_year']['widget'][0]['value']['#default_value'] < 0) ? TRUE : FALSE
+        '#default_value' => ($form['field_end_year']['widget'][0]['value']['#default_value'] < 0) ? TRUE : FALSE,
       ];
 
       $form['#attached']['library'][] = 'helhist_admin_forms/finna_import';
@@ -164,8 +166,8 @@ function helhist_admin_forms_form_webform_ui_element_type_select_form_alter(&$fo
 }
 
 /**
-* Implements Ajax custom callback function().
-*/
+ * Implements Ajax custom callback function().
+ */
 function helhist_admin_forms_ajax_end_year_default($form, $form_state) {
   if (!$form['field_start_year']['time_period']['#checked']) {
     $response = new AjaxResponse();
@@ -181,8 +183,8 @@ function helhist_admin_forms_ajax_end_year_default($form, $form_state) {
 }
 
 /**
-* Implements Ajax custom callback function().
-*/
+ * Implements Ajax custom callback function().
+ */
 function helhist_admin_forms_ajax_start_year_bce($form, $form_state) {
   $response = new AjaxResponse();
   $start_year = $form['field_start_year']['widget'][0]['value']['#value'];
@@ -196,8 +198,8 @@ function helhist_admin_forms_ajax_start_year_bce($form, $form_state) {
 }
 
 /**
-* Implements Ajax custom callback function().
-*/
+ * Implements Ajax custom callback function().
+ */
 function helhist_admin_forms_ajax_end_year_bce($form, $form_state) {
   $response = new AjaxResponse();
   $end_year = $form['field_end_year']['widget'][0]['value']['#value'];

--- a/public/modules/custom/helhist_admin_forms/src/Plugin/views/field/EntityTranslationsField.php
+++ b/public/modules/custom/helhist_admin_forms/src/Plugin/views/field/EntityTranslationsField.php
@@ -1,10 +1,6 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\helhist_admin_forms\Plugin\views\field\EntityTranslationsField
- *
- */
+declare(strict_types=1);
 
 namespace Drupal\helhist_admin_forms\Plugin\views\field;
 
@@ -12,6 +8,8 @@ use Drupal\views\Plugin\views\field\FieldPluginBase;
 use Drupal\views\ResultRow;
 
 /**
+ * Views field handler for entity translations.
+ *
  * @ingroup views_field_handlers
  *
  * @ViewsField("entity_translations_field")
@@ -55,7 +53,7 @@ class EntityTranslationsField extends FieldPluginBase {
     ];
     foreach ($langcodes as $langcode) {
       if ($entity->hasTranslation($langcode)) {
-        $translations['#items'][] = ['#markup' => $langcode,];
+        $translations['#items'][] = ['#markup' => $langcode];
       }
     }
 

--- a/public/modules/custom/helhist_admin_forms/src/Plugin/views/field/EntityTranslationsField.php
+++ b/public/modules/custom/helhist_admin_forms/src/Plugin/views/field/EntityTranslationsField.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @ingroup views_field_handlers
  *
  * @ViewsField("entity_translations_field")
- * 
+ *
  * @phpstan-consistent-constructor
  */
 class EntityTranslationsField extends FieldPluginBase {
@@ -80,8 +80,7 @@ class EntityTranslationsField extends FieldPluginBase {
   /**
    * {@inheritdoc}
    */
-  // @phpstan-ignore-next-line
-  public function render(ResultRow $values): array {
+  public function render(ResultRow $values) {
     $entity = $values->_entity;
     $langcodes = array_keys($this->languageManager->getLanguages());
     $translations = [
@@ -98,6 +97,9 @@ class EntityTranslationsField extends FieldPluginBase {
       }
     }
 
+    // Views handles render arrays internally, even though the interface
+    // signature specifies MarkupInterface|string.
+    // @phpstan-ignore-next-line
     return $translations;
   }
 

--- a/public/modules/custom/helhist_article/helhist_article.module
+++ b/public/modules/custom/helhist_article/helhist_article.module
@@ -42,6 +42,7 @@ function helhist_article_pathauto_alias_alter(&$alias, array &$context) {
       $term_label = $term->label();
 
       $vocabulary_config = \Drupal::config('taxonomy.vocabulary.' . $term->bundle());
+      // @phpstan-ignore-next-line
       $vocabulary_translated_config = \Drupal::languageManager()->getLanguageConfigOverride($language, 'taxonomy.vocabulary.' . $term->bundle());
       // Use translation if possible.
       $vocabulary_label = $vocabulary_translated_config->get('name') == '' ? $vocabulary_config->get('name') : $vocabulary_translated_config->get('name');

--- a/public/modules/custom/helhist_article/helhist_article.module
+++ b/public/modules/custom/helhist_article/helhist_article.module
@@ -1,28 +1,33 @@
 <?php
 
-use Drupal\Core\Language\LanguageInterface;
-use Drupal\node\Entity\Node;
-use Drupal\taxonomy\Entity\Term;
-use Drupal\taxonomy\Entity\Vocabulary;
+/**
+ * @file
+ * Custom functionality for helhist_article module.
+ */
+
+declare(strict_types=1);
 
 /**
  * Implements hook_pathauto_alias_alter().
  */
 function helhist_article_pathauto_alias_alter(&$alias, array &$context) {
-   // Check if the content is node and the bundle is an article
-   if ($context['module'] === 'node' && $context['bundle'] === 'article') {
+  // Check if the content is node and the bundle is an article.
+  if ($context['module'] === 'node' && $context['bundle'] === 'article') {
 
     $node = $context['data']['node'];
     $language = $context['language'];
 
     $clean_string_service = \Drupal::service('pathauto.alias_cleaner');
 
-    // Phenomena field takes precedence, then neighbourhoods, then turning points
+    // Phenomena field takes precedence, then neighbourhoods, then turning
+    // points.
     if ($node->get('field_phenomena')->target_id != NULL) {
       $termreference = $node->get('field_phenomena')->target_id;
-    } else if ($node->get('field_neighbourhoods')->target_id != NULL) {
+    }
+    elseif ($node->get('field_neighbourhoods')->target_id != NULL) {
       $termreference = $node->get('field_neighbourhoods')->target_id;
-    } else if ($node->get('field_turning_points')->target_id != NULL) {
+    }
+    elseif ($node->get('field_turning_points')->target_id != NULL) {
       $termreference = $node->get('field_turning_points')->target_id;
     }
 
@@ -30,7 +35,7 @@ function helhist_article_pathauto_alias_alter(&$alias, array &$context) {
       $node_label = $node->label();
 
       $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->load($termreference);
-      // Get translation if possible
+      // Get translation if possible.
       if ($term->hasTranslation($language)) {
         $term = \Drupal::service('entity.repository')->getTranslationFromContext($term, $language);
       }
@@ -38,7 +43,7 @@ function helhist_article_pathauto_alias_alter(&$alias, array &$context) {
 
       $vocabulary_config = \Drupal::config('taxonomy.vocabulary.' . $term->bundle());
       $vocabulary_translated_config = \Drupal::languageManager()->getLanguageConfigOverride($language, 'taxonomy.vocabulary.' . $term->bundle());
-      // Use translation if possible
+      // Use translation if possible.
       $vocabulary_label = $vocabulary_translated_config->get('name') == '' ? $vocabulary_config->get('name') : $vocabulary_translated_config->get('name');
 
       $vocabulary_label = '/' . $clean_string_service->cleanString($vocabulary_label);
@@ -53,8 +58,9 @@ function helhist_article_pathauto_alias_alter(&$alias, array &$context) {
 /**
  * Implements hook_entity_type_alter().
  *
- * Attempting to fix error "Non-translatable fields can only be changed when updating the original language."
- * with Paragraphs + Content Moderation + Translations: https://www.drupal.org/project/drupal/issues/3025039
+ * Attempting to fix error "Non-translatable fields can only be changed when
+ * updating the original language." with Paragraphs + Content Moderation +
+ * Translations: https://www.drupal.org/project/drupal/issues/3025039
  */
 function helhist_article_entity_type_alter(array &$entity_types) {
   foreach ($entity_types as $entity_type) {

--- a/public/modules/custom/helhist_article/src/ArticlePathAlias.php
+++ b/public/modules/custom/helhist_article/src/ArticlePathAlias.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\mymodule;
 
 use Drupal\Component\Utility\Html;
@@ -10,19 +12,48 @@ use Drupal\taxonomy\Entity\Term;
  */
 class ArticlePathAlias {
 
+  /**
+   * Map of term names to custom aliases.
+   *
+   * @var array
+   */
   protected $terms = [
     'Term name 1' => 'custom/alias',
     'Term name 2' => 'custom2/alias',
     'Term name 3' => 'custom3/alias',
   ];
+
+  /**
+   * URL pattern template for article aliases.
+   *
+   * @var string
+   */
   protected $pattern = '/%term%/%year%/%monthnum%/%day%/%postname%';
 
+  /**
+   * Generate a URL alias for an article.
+   *
+   * @param array $context
+   *   The context containing bundle, operation, and node data.
+   *
+   * @return string|null
+   *   The generated alias or NULL if not applicable.
+   */
   public function generate($context) {
     if ($context['bundle'] === 'article' && ($context['op'] == 'insert' || $context['op'] == 'update')) {
       return $this->assembleAlias($context['data']['node']);
     }
   }
 
+  /**
+   * Assemble the URL alias using the pattern and entity data.
+   *
+   * @param \Drupal\node\NodeInterface $entity
+   *   The article node entity.
+   *
+   * @return string|null
+   *   The assembled alias or NULL if no term alias found.
+   */
   protected function assembleAlias($entity) {
     $date = new \DateTime(date('c', $entity->getCreatedTime()));
     $parameters = [
@@ -37,8 +68,18 @@ class ArticlePathAlias {
     }
   }
 
+  /**
+   * Find the term alias for the given entity.
+   *
+   * @param \Drupal\node\NodeInterface $entity
+   *   The article node entity.
+   *
+   * @return string|null
+   *   The term alias or NULL if not found.
+   */
   protected function findTermAlias($entity) {
-    // Make sure to change `field_keywords` to the field you would like to check.
+    // Make sure to change `field_keywords` to the field you would
+    // like to check.
     if ($keywords = $entity->get('field_keywords')->getValue()) {
       foreach ($keywords as $data) {
         $term = Term::load($data['target_id']);
@@ -49,4 +90,5 @@ class ArticlePathAlias {
       }
     }
   }
+
 }

--- a/public/modules/custom/helhist_article/src/ArticlePathAlias.php
+++ b/public/modules/custom/helhist_article/src/ArticlePathAlias.php
@@ -43,7 +43,7 @@ class ArticlePathAlias {
     if ($context['bundle'] === 'article' && ($context['op'] == 'insert' || $context['op'] == 'update')) {
       return $this->assembleAlias($context['data']['node']);
     }
-    return null;
+    return NULL;
   }
 
   /**
@@ -67,7 +67,7 @@ class ArticlePathAlias {
     if (!empty($parameters['%term%'])) {
       return str_replace(array_keys($parameters), array_values($parameters), $this->pattern);
     }
-    return null;
+    return NULL;
   }
 
   /**
@@ -91,7 +91,7 @@ class ArticlePathAlias {
         }
       }
     }
-    return null;
+    return NULL;
   }
 
 }

--- a/public/modules/custom/helhist_article/src/ArticlePathAlias.php
+++ b/public/modules/custom/helhist_article/src/ArticlePathAlias.php
@@ -43,6 +43,7 @@ class ArticlePathAlias {
     if ($context['bundle'] === 'article' && ($context['op'] == 'insert' || $context['op'] == 'update')) {
       return $this->assembleAlias($context['data']['node']);
     }
+    return null;
   }
 
   /**
@@ -66,6 +67,7 @@ class ArticlePathAlias {
     if (!empty($parameters['%term%'])) {
       return str_replace(array_keys($parameters), array_values($parameters), $this->pattern);
     }
+    return null;
   }
 
   /**
@@ -89,6 +91,7 @@ class ArticlePathAlias {
         }
       }
     }
+    return null;
   }
 
 }

--- a/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReArchives.php
+++ b/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReArchives.php
@@ -19,13 +19,15 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   id = "kore_archives",
  *   handle_multiples = TRUE
  * )
+ *
+ * @phpstan-consistent-constructor
  */
 class KoReArchives extends ProcessPluginBase implements ContainerFactoryPluginInterface {
 
   /**
    * Logger service.
    *
-   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
    */
   protected $logger;
 

--- a/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReArchives.php
+++ b/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReArchives.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\helhist_kore\Plugin\migrate\process;
 
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\migrate\MigrateExecutableInterface;
 use Drupal\migrate\ProcessPluginBase;
 use Drupal\migrate\Row;
@@ -12,6 +13,8 @@ use Drupal\paragraphs\Entity\Paragraph;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
+ * Processes KoRe archive data for migration.
+ *
  * @MigrateProcessPlugin(
  *   id = "kore_archives",
  *   handle_multiples = TRUE
@@ -88,6 +91,15 @@ class KoReArchives extends ProcessPluginBase implements ContainerFactoryPluginIn
     return ($ac > $bc) ? -1 : 1;
   }
 
+  /**
+   * Creates a paragraph item for archive data.
+   *
+   * @param array $item
+   *   The item data array.
+   *
+   * @return array
+   *   The paragraph reference array.
+   */
   protected function createParagraphsItem(array $item): array {
 
     $paragraph = Paragraph::create([
@@ -107,7 +119,7 @@ class KoReArchives extends ProcessPluginBase implements ContainerFactoryPluginIn
       'field_kore_url' => [
         'uri' => str_replace('https://yksa3.darchive.fi/YKSA3/id/', 'https://yksa.disec.fi/Yksa4/id/', $item['url']),
         'title' => $item['arkiston_nimi'],
-      ]
+      ],
     ]);
 
     $paragraph->save();

--- a/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReBuildings.php
+++ b/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReBuildings.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\helhist_kore\Plugin\migrate\process;
 
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\migrate\MigrateExecutableInterface;
 use Drupal\migrate\ProcessPluginBase;
 use Drupal\migrate\Row;
@@ -12,6 +13,8 @@ use Drupal\paragraphs\Entity\Paragraph;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
+ * Processes KoRe building data for migration.
+ *
  * @MigrateProcessPlugin(
  *   id = "kore_buildings",
  *   handle_multiples = TRUE
@@ -88,6 +91,15 @@ class KoReBuildings extends ProcessPluginBase implements ContainerFactoryPluginI
     return ($ac > $bc) ? -1 : 1;
   }
 
+  /**
+   * Creates a paragraph item for building data.
+   *
+   * @param array $item
+   *   The item data array.
+   *
+   * @return array
+   *   The paragraph reference array.
+   */
   protected function createParagraphsItem(array $item): array {
 
     $paragraph = Paragraph::create([

--- a/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReBuildings.php
+++ b/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReBuildings.php
@@ -19,13 +19,15 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   id = "kore_buildings",
  *   handle_multiples = TRUE
  * )
+ *
+ * @phpstan-consistent-constructor
  */
 class KoReBuildings extends ProcessPluginBase implements ContainerFactoryPluginInterface {
 
   /**
    * Logger service.
    *
-   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
    */
   protected $logger;
 

--- a/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReContinuums.php
+++ b/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReContinuums.php
@@ -20,13 +20,15 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   id = "kore_continuums",
  *   handle_multiples = TRUE
  * )
+ *
+ * @phpstan-consistent-constructor
  */
 class KoReContinuums extends ProcessPluginBase implements ContainerFactoryPluginInterface {
 
   /**
    * Logger service.
    *
-   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
    */
   protected $logger;
 
@@ -68,7 +70,7 @@ class KoReContinuums extends ProcessPluginBase implements ContainerFactoryPlugin
 
     $value = array_merge($value[0], $value[1]);
 
-    if (isset($value)) {
+    if (!empty($value)) {
       uasort($value, [$this, 'compare']);
       foreach ($value as $item) {
         $paragraphs[] = $this->createParagraphsItem($item);
@@ -123,6 +125,7 @@ class KoReContinuums extends ProcessPluginBase implements ContainerFactoryPlugin
     ]);
 
     if (is_array($item['target_school'])) {
+      // @phpstan-ignore-next-line
       $school_node = \Drupal::entityQuery('node')
         ->accessCheck(FALSE)
         ->condition('type', 'kore_school')
@@ -130,6 +133,7 @@ class KoReContinuums extends ProcessPluginBase implements ContainerFactoryPlugin
         ->execute();
     }
     elseif (is_array($item['active_school'])) {
+      // @phpstan-ignore-next-line
       $school_node = \Drupal::entityQuery('node')
         ->accessCheck(FALSE)
         ->condition('type', 'kore_school')

--- a/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReContinuums.php
+++ b/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReContinuums.php
@@ -1,9 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\helhist_kore\Plugin\migrate\process;
 
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
 use Drupal\migrate\MigrateExecutableInterface;
 use Drupal\migrate\ProcessPluginBase;
@@ -12,6 +14,8 @@ use Drupal\paragraphs\Entity\Paragraph;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
+ * Processes KoRe continuum data for migration.
+ *
  * @MigrateProcessPlugin(
  *   id = "kore_continuums",
  *   handle_multiples = TRUE
@@ -63,7 +67,7 @@ class KoReContinuums extends ProcessPluginBase implements ContainerFactoryPlugin
     $paragraphs = [];
 
     $value = array_merge($value[0], $value[1]);
-   
+
     if (isset($value)) {
       uasort($value, [$this, 'compare']);
       foreach ($value as $item) {
@@ -90,6 +94,15 @@ class KoReContinuums extends ProcessPluginBase implements ContainerFactoryPlugin
     return ($ac > $bc) ? -1 : 1;
   }
 
+  /**
+   * Creates a paragraph item for continuum data.
+   *
+   * @param array $item
+   *   The item data array.
+   *
+   * @return array
+   *   The paragraph reference array.
+   */
   protected function createParagraphsItem(array $item): array {
 
     if ($item['year']) {
@@ -110,22 +123,18 @@ class KoReContinuums extends ProcessPluginBase implements ContainerFactoryPlugin
     ]);
 
     if (is_array($item['target_school'])) {
-      foreach ($item['target_school']['names'] as $name) {
-        $school_node = \Drupal::entityQuery('node')
+      $school_node = \Drupal::entityQuery('node')
         ->accessCheck(FALSE)
         ->condition('type', 'kore_school')
         ->condition('field_kore_id', $item['target_school']['id'])
         ->execute();
-      }
     }
-    else if (is_array($item['active_school'])) {
-      foreach ($item['active_school']['names'] as $name) {
-        $school_node = \Drupal::entityQuery('node')
+    elseif (is_array($item['active_school'])) {
+      $school_node = \Drupal::entityQuery('node')
         ->accessCheck(FALSE)
         ->condition('type', 'kore_school')
         ->condition('field_kore_id', $item['active_school']['id'])
         ->execute();
-      }
     }
 
     if (isset($school_node)) {

--- a/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReFields.php
+++ b/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReFields.php
@@ -19,13 +19,15 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   id = "kore_fields",
  *   handle_multiples = TRUE
  * )
+ *
+ * @phpstan-consistent-constructor
  */
 class KoReFields extends ProcessPluginBase implements ContainerFactoryPluginInterface {
 
   /**
    * Logger service.
    *
-   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
    */
   protected $logger;
 

--- a/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReFields.php
+++ b/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReFields.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\helhist_kore\Plugin\migrate\process;
 
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\migrate\MigrateExecutableInterface;
 use Drupal\migrate\ProcessPluginBase;
 use Drupal\migrate\Row;
@@ -12,6 +13,8 @@ use Drupal\paragraphs\Entity\Paragraph;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
+ * Processes KoRe field data for migration.
+ *
  * @MigrateProcessPlugin(
  *   id = "kore_fields",
  *   handle_multiples = TRUE
@@ -88,6 +91,15 @@ class KoReFields extends ProcessPluginBase implements ContainerFactoryPluginInte
     return ($ac > $bc) ? -1 : 1;
   }
 
+  /**
+   * Creates a paragraph item for field data.
+   *
+   * @param array $item
+   *   The item data array.
+   *
+   * @return array
+   *   The paragraph reference array.
+   */
   protected function createParagraphsItem(array $item): array {
 
     $item['field']['name'] = str_replace(['-', ' '], '_', $item['field']['name']);

--- a/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReGenders.php
+++ b/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReGenders.php
@@ -19,13 +19,15 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   id = "kore_genders",
  *   handle_multiples = TRUE
  * )
+ *
+ * @phpstan-consistent-constructor
  */
 class KoReGenders extends ProcessPluginBase implements ContainerFactoryPluginInterface {
 
   /**
    * Logger service.
    *
-   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
    */
   protected $logger;
 

--- a/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReGenders.php
+++ b/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReGenders.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\helhist_kore\Plugin\migrate\process;
 
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\migrate\MigrateExecutableInterface;
 use Drupal\migrate\ProcessPluginBase;
 use Drupal\migrate\Row;
@@ -12,6 +13,8 @@ use Drupal\paragraphs\Entity\Paragraph;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
+ * Provides a plugin for migrating KoRe genders.
+ *
  * @MigrateProcessPlugin(
  *   id = "kore_genders",
  *   handle_multiples = TRUE
@@ -88,6 +91,9 @@ class KoReGenders extends ProcessPluginBase implements ContainerFactoryPluginInt
     return ($ac > $bc) ? -1 : 1;
   }
 
+  /**
+   * Creates a paragraphs item.
+   */
   protected function createParagraphsItem(array $item): array {
 
     $item['gender'] = str_replace(['-', ' '], '_', $item['gender']);

--- a/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReLanguages.php
+++ b/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReLanguages.php
@@ -19,13 +19,15 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   id = "kore_languages",
  *   handle_multiples = TRUE
  * )
+ *
+ * @phpstan-consistent-constructor
  */
 class KoReLanguages extends ProcessPluginBase implements ContainerFactoryPluginInterface {
 
   /**
    * Logger service.
    *
-   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
    */
   protected $logger;
 

--- a/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReLanguages.php
+++ b/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReLanguages.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\helhist_kore\Plugin\migrate\process;
 
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\migrate\MigrateExecutableInterface;
 use Drupal\migrate\ProcessPluginBase;
 use Drupal\migrate\Row;
@@ -12,6 +13,8 @@ use Drupal\paragraphs\Entity\Paragraph;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
+ * Processes KoRe language data for migration.
+ *
  * @MigrateProcessPlugin(
  *   id = "kore_languages",
  *   handle_multiples = TRUE
@@ -88,6 +91,15 @@ class KoReLanguages extends ProcessPluginBase implements ContainerFactoryPluginI
     return ($ac > $bc) ? -1 : 1;
   }
 
+  /**
+   * Creates a paragraph item for language data.
+   *
+   * @param array $item
+   *   The item data array.
+   *
+   * @return array
+   *   The paragraph reference array.
+   */
   protected function createParagraphsItem(array $item): array {
 
     $item['language'] = str_replace(['-', ' '], '_', $item['language']);

--- a/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReNames.php
+++ b/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReNames.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\helhist_kore\Plugin\migrate\process;
 
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\migrate\MigrateExecutableInterface;
 use Drupal\migrate\ProcessPluginBase;
 use Drupal\migrate\Row;
@@ -12,6 +13,8 @@ use Drupal\paragraphs\Entity\Paragraph;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
+ * Processes KoRe name data for migration.
+ *
  * @MigrateProcessPlugin(
  *   id = "kore_names",
  *   handle_multiples = TRUE
@@ -88,6 +91,15 @@ class KoReNames extends ProcessPluginBase implements ContainerFactoryPluginInter
     return ($ac > $bc) ? -1 : 1;
   }
 
+  /**
+   * Creates a paragraph item for name data.
+   *
+   * @param array $item
+   *   The item data array.
+   *
+   * @return array
+   *   The paragraph reference array.
+   */
   protected function createParagraphsItem(array $item): array {
 
     $paragraph = Paragraph::create([

--- a/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReNames.php
+++ b/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReNames.php
@@ -19,13 +19,15 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   id = "kore_names",
  *   handle_multiples = TRUE
  * )
+ *
+ * @phpstan-consistent-constructor
  */
 class KoReNames extends ProcessPluginBase implements ContainerFactoryPluginInterface {
 
   /**
    * Logger service.
    *
-   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
    */
   protected $logger;
 

--- a/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoRePhotos.php
+++ b/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoRePhotos.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Drupal\helhist_kore\Plugin\migrate\process;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\File\FileExists;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\migrate\MigrateExecutableInterface;
@@ -20,13 +20,15 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   id = "kore_photos",
  *   handle_multiples = TRUE
  * )
+ *
+ * @phpstan-consistent-constructor
  */
 class KoRePhotos extends ProcessPluginBase implements ContainerFactoryPluginInterface {
 
   /**
    * Logger service.
    *
-   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
    */
   protected $logger;
 
@@ -126,9 +128,11 @@ class KoRePhotos extends ProcessPluginBase implements ContainerFactoryPluginInte
       return [];
     }
 
+    // @phpstan-ignore-next-line
     $file_repository = \Drupal::service('file.repository');
-    $image = $file_repository->writeData($image_data, 'public://' . $item['id'] . '.jpg', FileSystemInterface::EXISTS_REPLACE);
+    $image = $file_repository->writeData($image_data, 'public://' . $item['id'] . '.jpg', FileExists::Replace);
 
+    // @phpstan-ignore-next-line
     $image_media = \Drupal::entityQuery('media')
       ->accessCheck(FALSE)
       ->condition('bundle', 'kore_image')

--- a/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoRePhotos.php
+++ b/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoRePhotos.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Drupal\helhist_kore\Plugin\migrate\process;
 
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\media\Entity\Media;
 use Drupal\migrate\MigrateExecutableInterface;
 use Drupal\migrate\ProcessPluginBase;
 use Drupal\migrate\Row;
@@ -31,6 +31,13 @@ class KoRePhotos extends ProcessPluginBase implements ContainerFactoryPluginInte
   protected $logger;
 
   /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
    * Constructs a plugin.
    *
    * @param array $configuration
@@ -41,10 +48,19 @@ class KoRePhotos extends ProcessPluginBase implements ContainerFactoryPluginInte
    *   The plugin definition.
    * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger
    *   The logger service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, LoggerChannelFactoryInterface $logger) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    LoggerChannelFactoryInterface $logger,
+    EntityTypeManagerInterface $entity_type_manager
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->logger = $logger->get('kore_schools');
+    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**
@@ -55,7 +71,8 @@ class KoRePhotos extends ProcessPluginBase implements ContainerFactoryPluginInte
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('logger.factory')
+      $container->get('logger.factory'),
+      $container->get('entity_type.manager')
     );
   }
 
@@ -120,11 +137,11 @@ class KoRePhotos extends ProcessPluginBase implements ContainerFactoryPluginInte
 
     if (!empty($image_media)) {
       foreach ($image_media as $mid) {
-        $image_media = Media::load($mid);
+        $image_media = $this->entityTypeManager->getStorage('media')->load($mid);
       }
     }
     else {
-      $image_media = Media::create([
+      $image_media = $this->entityTypeManager->getStorage('media')->create([
         'name' => $item['id'],
         'bundle' => 'kore_image',
         'uid' => 1,

--- a/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoRePhotos.php
+++ b/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoRePhotos.php
@@ -1,19 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\helhist_kore\Plugin\migrate\process;
 
 use Drupal\Core\File\FileSystemInterface;
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\media\Entity\Media;
 use Drupal\migrate\MigrateExecutableInterface;
 use Drupal\migrate\ProcessPluginBase;
 use Drupal\migrate\Row;
-use Drupal\paragraphs\Entity\Paragraph;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
+ * Provides a plugin for migrating KoRe photos.
+ *
  * @MigrateProcessPlugin(
  *   id = "kore_photos",
  *   handle_multiples = TRUE
@@ -82,19 +84,22 @@ class KoRePhotos extends ProcessPluginBase implements ContainerFactoryPluginInte
     return TRUE;
   }
 
+  /**
+   * Creates a media item.
+   */
   protected function createMediaItem(array $item): array {
 
     if (!$image_data = file_get_contents($item['url'])) {
       return [];
     }
 
-    // Get Finna metadata
-    if(str_starts_with($item['url'], 'https://hkm.finna.fi/Cover/Show?id=')) {
+    // Get Finna metadata.
+    if (str_starts_with($item['url'], 'https://hkm.finna.fi/Cover/Show?id=')) {
       $finna_url = str_replace('https://hkm.finna.fi/Cover/Show?id=', 'https://api.finna.fi/v1/record?id=', $item['url']);
       $finna_json = file_get_contents($finna_url);
       $finna_json = json_decode($finna_json);
     }
-    elseif(str_starts_with($item['url'], 'https://www.finna.fi/Cover/Show?id=')) {
+    elseif (str_starts_with($item['url'], 'https://www.finna.fi/Cover/Show?id=')) {
       $finna_url = str_replace('https://www.finna.fi/Cover/Show?id=', 'https://api.finna.fi/v1/record?id=', $item['url']);
       $finna_json = file_get_contents($finna_url);
       $finna_json = json_decode($finna_json);
@@ -108,13 +113,13 @@ class KoRePhotos extends ProcessPluginBase implements ContainerFactoryPluginInte
     $image = $file_repository->writeData($image_data, 'public://' . $item['id'] . '.jpg', FileSystemInterface::EXISTS_REPLACE);
 
     $image_media = \Drupal::entityQuery('media')
-                   ->accessCheck(FALSE)
-                   ->condition('bundle', 'kore_image')
-                   ->condition('name', $item['id'])
-                   ->execute();
+      ->accessCheck(FALSE)
+      ->condition('bundle', 'kore_image')
+      ->condition('name', $item['id'])
+      ->execute();
 
     if (!empty($image_media)) {
-      foreach($image_media as $mid) {
+      foreach ($image_media as $mid) {
         $image_media = Media::load($mid);
       }
     }

--- a/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoRePrincipals.php
+++ b/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoRePrincipals.php
@@ -19,13 +19,15 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   id = "kore_principals",
  *   handle_multiples = TRUE
  * )
+ *
+ * @phpstan-consistent-constructor
  */
 class KoRePrincipals extends ProcessPluginBase implements ContainerFactoryPluginInterface {
 
   /**
    * Logger service.
    *
-   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
    */
   protected $logger;
 

--- a/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoRePrincipals.php
+++ b/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoRePrincipals.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\helhist_kore\Plugin\migrate\process;
 
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\migrate\MigrateExecutableInterface;
 use Drupal\migrate\ProcessPluginBase;
 use Drupal\migrate\Row;
@@ -12,6 +13,8 @@ use Drupal\paragraphs\Entity\Paragraph;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
+ * Processes KoRe principal data for migration.
+ *
  * @MigrateProcessPlugin(
  *   id = "kore_principals",
  *   handle_multiples = TRUE
@@ -88,6 +91,15 @@ class KoRePrincipals extends ProcessPluginBase implements ContainerFactoryPlugin
     return ($ac > $bc) ? -1 : 1;
   }
 
+  /**
+   * Creates a paragraph item for principal data.
+   *
+   * @param array $item
+   *   The item data array.
+   *
+   * @return array
+   *   The paragraph reference array.
+   */
   protected function createParagraphsItem(array $item): array {
 
     $paragraph = Paragraph::create([

--- a/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReTitle.php
+++ b/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReTitle.php
@@ -1,17 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\helhist_kore\Plugin\migrate\process;
 
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\migrate\MigrateExecutableInterface;
 use Drupal\migrate\ProcessPluginBase;
 use Drupal\migrate\Row;
-use Drupal\paragraphs\Entity\Paragraph;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
+ * Processes KoRe title data for migration.
+ *
  * @MigrateProcessPlugin(
  *   id = "kore_title",
  *   handle_multiples = TRUE
@@ -67,7 +69,7 @@ class KoReTitle extends ProcessPluginBase implements ContainerFactoryPluginInter
       if (is_array($latest) && !empty($latest['official_name'])) {
         return $latest['official_name'];
       }
-      else if (is_array($latest['other_names']) && !empty($latest['other_names'][0]['value'])) {
+      elseif (is_array($latest['other_names']) && !empty($latest['other_names'][0]['value'])) {
         return $latest['other_names'][0]['value'];
       }
     }

--- a/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReTitle.php
+++ b/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReTitle.php
@@ -18,13 +18,15 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   id = "kore_title",
  *   handle_multiples = TRUE
  * )
+ *
+ * @phpstan-consistent-constructor
  */
 class KoReTitle extends ProcessPluginBase implements ContainerFactoryPluginInterface {
 
   /**
    * Logger service.
    *
-   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
    */
   protected $logger;
 

--- a/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReTypes.php
+++ b/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReTypes.php
@@ -19,13 +19,15 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   id = "kore_types",
  *   handle_multiples = TRUE
  * )
+ *
+ * @phpstan-consistent-constructor
  */
 class KoReTypes extends ProcessPluginBase implements ContainerFactoryPluginInterface {
 
   /**
    * Logger service.
    *
-   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
    */
   protected $logger;
 

--- a/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReTypes.php
+++ b/public/modules/custom/helhist_kore/src/Plugin/migrate/process/KoReTypes.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\helhist_kore\Plugin\migrate\process;
 
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\migrate\MigrateExecutableInterface;
 use Drupal\migrate\ProcessPluginBase;
 use Drupal\migrate\Row;
@@ -12,6 +13,8 @@ use Drupal\paragraphs\Entity\Paragraph;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
+ * Provides a plugin for migrating KoRe types.
+ *
  * @MigrateProcessPlugin(
  *   id = "kore_types",
  *   handle_multiples = TRUE
@@ -88,6 +91,9 @@ class KoReTypes extends ProcessPluginBase implements ContainerFactoryPluginInter
     return ($ac > $bc) ? -1 : 1;
   }
 
+  /**
+   * Creates a paragraphs item.
+   */
   protected function createParagraphsItem(array $item): array {
 
     $item['type']['name'] = str_replace(['-', ' '], '_', $item['type']['name']);

--- a/public/modules/custom/helhist_kore_admin/helhist_kore_admin.module
+++ b/public/modules/custom/helhist_kore_admin/helhist_kore_admin.module
@@ -1,7 +1,14 @@
 <?php
 
+/**
+ * @file
+ * Provides Helhist Kore search related modifications.
+ */
 
-use \Drupal\Core\Form\FormStateInterface;
+declare(strict_types=1);
+
+use Drupal\Core\Form\FormStateInterface;
+
 /**
  * @file
  * Primary module hooks for helhist_kore_admin module.

--- a/public/modules/custom/helhist_kore_admin/src/Form/KoreSettingsForm.php
+++ b/public/modules/custom/helhist_kore_admin/src/Form/KoreSettingsForm.php
@@ -1,11 +1,6 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\helhist_kore_admin\Form\KoreSettingsForm.
- *
- * Provides a form for managing Koulurekisteri search page content.
- */
+declare(strict_types=1);
 
 namespace Drupal\helhist_kore_admin\Form;
 
@@ -15,86 +10,86 @@ use Drupal\Core\Language\LanguageManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Kore Settings Form
+ * Kore Settings Form.
  */
 class KoreSettingsForm extends ConfigFormBase {
 
-    /**
-     * The language manager.
-     *
-     * @var \Drupal\Core\Language\LanguageManagerInterface
-     */
-    protected $languageManager;
+  /**
+   * The language manager.
+   *
+   * @var \Drupal\Core\Language\LanguageManagerInterface
+   */
+  protected $languageManager;
 
-    /**
-     * Constructs a new KoreSettingsForm.
-     *
-     * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
-     *   The language manager service.
-     */
-    public function __construct(LanguageManagerInterface $language_manager) {
-        $this->languageManager = $language_manager;
-    }
+  /**
+   * Constructs a new KoreSettingsForm.
+   *
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   *   The language manager service.
+   */
+  public function __construct(LanguageManagerInterface $language_manager) {
+    $this->languageManager = $language_manager;
+  }
 
-    /**
-     * {@inheritdoc}
-     */
-    public static function create(ContainerInterface $container) {
-        return new static(
-            $container->get('language_manager')
-        );
-    }
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+          $container->get('language_manager')
+      );
+  }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getFormId() {
-        return 'helhist_kore_admin_settings';
-    }
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'helhist_kore_admin_settings';
+  }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getEditableConfigNames() {
-        return ['helhist_kore_admin.settings'];
-    }
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['helhist_kore_admin.settings'];
+  }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function buildForm(array $form, FormStateInterface $form_state) {
-        $config = $this->config('helhist_kore_admin.settings');
-        $current_language = $this->languageManager->getCurrentLanguage()->getId();
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('helhist_kore_admin.settings');
+    $current_language = $this->languageManager->getCurrentLanguage()->getId();
 
-        $form['kore_search_title'] = [
-            '#type' => 'textfield',
-            '#title' => $this->t('Koulurekisteri search page heading'),
-            '#default_value' => $config->get('kore_search_title.' . $current_language) ?? '',
-            '#weight' => -1,
-        ];
+    $form['kore_search_title'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Koulurekisteri search page heading'),
+      '#default_value' => $config->get('kore_search_title.' . $current_language) ?? '',
+      '#weight' => -1,
+    ];
 
-        $form['kore_search_text'] = [
-            '#type' => 'text_format',
-            '#title' => $this->t('Koulurekisteri search page content'),
-            '#default_value' => $config->get('kore_search_text.' . $current_language)['value'] ?? '',
-            '#format' => 'full_html',
-            '#weight' => 0,
-        ];
+    $form['kore_search_text'] = [
+      '#type' => 'text_format',
+      '#title' => $this->t('Koulurekisteri search page content'),
+      '#default_value' => $config->get('kore_search_text.' . $current_language)['value'] ?? '',
+      '#format' => 'full_html',
+      '#weight' => 0,
+    ];
 
-        return parent::buildForm($form, $form_state);
-    }
+    return parent::buildForm($form, $form_state);
+  }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function submitForm(array &$form, FormStateInterface $form_state) {
-        $current_language = $this->languageManager->getCurrentLanguage()->getId();
-        $this->config('helhist_kore_admin.settings')
-            ->set('kore_search_title.' . $current_language, $form_state->getValue('kore_search_title'))
-            ->set('kore_search_text.' . $current_language, $form_state->getValue('kore_search_text'))
-            ->save();
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $current_language = $this->languageManager->getCurrentLanguage()->getId();
+    $this->config('helhist_kore_admin.settings')
+      ->set('kore_search_title.' . $current_language, $form_state->getValue('kore_search_title'))
+      ->set('kore_search_text.' . $current_language, $form_state->getValue('kore_search_text'))
+      ->save();
 
-        parent::submitForm($form, $form_state);
-    }
+    parent::submitForm($form, $form_state);
+  }
 
 }

--- a/public/modules/custom/helhist_kore_admin/src/Form/KoreSettingsForm.php
+++ b/public/modules/custom/helhist_kore_admin/src/Form/KoreSettingsForm.php
@@ -11,6 +11,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Kore Settings Form.
+ *
+ * @phpstan-consistent-constructor
  */
 class KoreSettingsForm extends ConfigFormBase {
 

--- a/public/modules/custom/helhist_kore_admin/src/Plugin/Block/KoreSearchContentBlock.php
+++ b/public/modules/custom/helhist_kore_admin/src/Plugin/Block/KoreSearchContentBlock.php
@@ -18,6 +18,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   admin_label = @Translation("KORE Search Content"),
  *   category = @Translation("KORE")
  * )
+ *
+ * @phpstan-consistent-constructor
  */
 class KoreSearchContentBlock extends BlockBase implements ContainerFactoryPluginInterface {
 

--- a/public/modules/custom/helhist_map/helhist_map.module
+++ b/public/modules/custom/helhist_map/helhist_map.module
@@ -1,34 +1,42 @@
 <?php
 
+/**
+ * @file
+ * Provides custom Helhist map functionalities.
+ */
+
+declare(strict_types=1);
+
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\node\NodeInterface;
 use Drupal\views\ViewExecutable;
 use Drupal\views\Views;
 
 /**
-* Implements hook_theme().
-*/
+ * Implements hook_theme().
+ */
 function helhist_map_theme($existing, $type, $theme, $path) {
   return [
     'map_controls' => [
       'template' => 'map-controls',
       'variables' => [
         'map_layers' => [],
-        'photo_layers' => []
-      ]
+        'photo_layers' => [],
       ],
+    ],
     'comparison_map_controls' => [
       'template' => 'comparison-map-controls',
       'variables' => [
         'map_layers' => [],
-        'photo_layers' => []
-      ]
+        'photo_layers' => [],
       ],
-      'map_lift_block' => [
-        'template' => 'map-lift-block',
-        'variables' => [
-          'map_node_url' => ''
-        ]
-      ]
+    ],
+    'map_lift_block' => [
+      'template' => 'map-lift-block',
+      'variables' => [
+        'map_node_url' => '',
+      ],
+    ],
   ];
 }
 
@@ -36,8 +44,8 @@ function helhist_map_theme($existing, $type, $theme, $path) {
  * Implements hook_views_post_execute().
  */
 function helhist_map_views_post_execute(ViewExecutable $view) {
-  if ($view->id() == 'combined_map' && in_array($view->current_display, _getMapDisplays())) {
-    // Apply exposed filters to media_map view result
+  if ($view->id() == 'combined_map' && in_array($view->current_display, helhist_map_get_map_displays())) {
+    // Apply exposed filters to media_map view result.
     $exposed_filters = $view->getExposedInput();
     $media_view = Views::getView('media_map');
     $media_view->setDisplay('block');
@@ -45,27 +53,27 @@ function helhist_map_views_post_execute(ViewExecutable $view) {
     $media_view->execute();
     $media_view_result = $media_view->result;
 
-    // Make media result indexes to follow article result indexes
+    // Make media result indexes to follow article result indexes.
     $new_media_index = count($view->result);
     foreach ($media_view_result as $key => $m_result) {
       $media_view_result[$key]->index = $new_media_index;
       $new_media_index++;
     }
 
-    // Merge media view results to article view results
+    // Merge media view results to article view results.
     $view->result = array_merge($view->result, $media_view_result);
     $view->total_rows = count($view->result);
-    
+
     $node = \Drupal::routeMatch()->getParameter('node');
-    if ($node instanceof \Drupal\node\NodeInterface && $node->bundle() == 'map_page') {
-      // Get the map center from field
+    if ($node instanceof NodeInterface && $node->bundle() == 'map_page') {
+      // Get the map center from field.
       if ($node->hasField('field_default_map_center') && !$node->get('field_default_map_center')->isEmpty()) {
         $default_map_center = $node->get('field_default_map_center')->first()->getValue();
         $view->style_plugin->options['map_position']['center']['lat'] = $default_map_center['lat'];
         $view->style_plugin->options['map_position']['center']['lon'] = $default_map_center['lon'];
       }
 
-      // Get the map zoom level from field
+      // Get the map zoom level from field.
       if ($node->hasField('field_default_map_zoom_level') && !$node->get('field_default_map_zoom_level')->isEmpty()) {
         $default_map_zoom_level = $node->get('field_default_map_zoom_level')->getString();
         $view->style_plugin->options['map_position']['zoom'] = $default_map_zoom_level;
@@ -78,7 +86,7 @@ function helhist_map_views_post_execute(ViewExecutable $view) {
  * Implements hook_views_pre_render().
  */
 function helhist_map_views_pre_render(ViewExecutable $view) {
-  if ($view->storage->id() == 'combined_map' && in_array($view->current_display, _getMapDisplays())) {
+  if ($view->storage->id() == 'combined_map' && in_array($view->current_display, helhist_map_get_map_displays())) {
     $view->element['#attached']['library'][] = 'hdbt_subtheme/map-view';
   }
 }
@@ -93,9 +101,15 @@ function helhist_map_leaflet_map_info_alter(array &$map_info) {
   }
 }
 
-function _getMapDisplays() {
+/**
+ * Get the list of map display IDs.
+ *
+ * @return array
+ *   An array of display IDs.
+ */
+function helhist_map_get_map_displays() {
   return [
-    'block'
+    'block',
   ];
 }
 
@@ -111,7 +125,7 @@ function helhist_map_form_alter(&$form, FormStateInterface $form_state, $form_id
   $taxonomy_field = 'field_keywords';
 
   if ($form['#id'] == $form_id) {
-    $active_terms = _get_active_terms($taxonomy_field, $select_field);
+    $active_terms = helhist_map_get_active_terms($taxonomy_field, $select_field);
     if (isset($active_terms)) {
       unset($form[$select_field]['#options']);
       $form[$select_field]['#options'] = ['All' => t('Select keyword')];
@@ -130,21 +144,26 @@ function helhist_map_form_alter(&$form, FormStateInterface $form_state, $form_id
 
 /**
  * Find taxonomy terms that return node results for a given field.
- * 
+ *
  * @param string $taxonomy_field
+ *   The taxonomy field name.
  * @param string $select_field
+ *   The select field name.
+ *
+ * @return array
+ *   An array of active terms.
  */
-function _get_active_terms($taxonomy_field, $select_field) {
+function helhist_map_get_active_terms($taxonomy_field, $select_field) {
   $term_list = [];
 
   // Find taxonomy terms that link to node type content with a geolocation.
   $connection = \Drupal::database();
-  $query = $connection->select('node__'.$taxonomy_field, 'node_field_data');
+  $query = $connection->select('node__' . $taxonomy_field, 'node_field_data');
   $query->join('node__field_geolocation', 'geolocation', 'geolocation.entity_id = node_field_data.entity_id');
   $query->join('taxonomy_term_field_data', 'tname', 'tname.tid = node_field_data.' . $select_field);
   // Let's restore this condition once we have translated terms.
-  // TODO: also add condition that node must have translation.
-  // $query->condition('tname.langcode', $language);
+  // @todo also add condition that node must have translation.
+  // $query->condition('tname.langcode', $language);.
   $query->fields('node_field_data', [$select_field]);
   $query->fields('tname', ['name']);
   $result = $query->distinct()->execute();
@@ -154,12 +173,12 @@ function _get_active_terms($taxonomy_field, $select_field) {
 
   // Find taxonomy terms that link to media type content with a geolocation.
   $connection = \Drupal::database();
-  $query = $connection->select('media__'.$taxonomy_field, 'media_field_data');
+  $query = $connection->select('media__' . $taxonomy_field, 'media_field_data');
   $query->join('media__field_geolocation', 'geolocation', 'geolocation.entity_id = media_field_data.entity_id');
   $query->join('taxonomy_term_field_data', 'tname', 'tname.tid = media_field_data.' . $select_field);
   // Let's restore this filter once we have translated terms.
-  // TODO: also add condition that media entity must have translation.
-  // $query->condition('tname.langcode', $language);
+  // @todo also add condition that media entity must have translation.
+  // $query->condition('tname.langcode', $language);.
   $query->fields('media_field_data', [$select_field]);
   $query->fields('tname', ['name']);
   $result = $query->distinct()->execute();
@@ -168,7 +187,7 @@ function _get_active_terms($taxonomy_field, $select_field) {
   }
 
   // Sort final options array.
-  usort($term_list, "_select_sort");
+  usort($term_list, "helhist_map_select_sort");
   return $term_list;
 }
 
@@ -176,8 +195,13 @@ function _get_active_terms($taxonomy_field, $select_field) {
  * Sort term list array by taxonomy name column.
  *
  * @param array $a
+ *   First array element to compare.
  * @param array $b
+ *   Second array element to compare.
+ *
+ * @return int
+ *   Comparison result.
  */
-function _select_sort ($a, $b) {
+function helhist_map_select_sort($a, $b) {
   return strcmp($a[1], $b[1]);
 }

--- a/public/modules/custom/helhist_map/helhist_map.services.yml
+++ b/public/modules/custom/helhist_map/helhist_map.services.yml
@@ -1,4 +1,4 @@
 services:
   helhist_map.mapservice:
     class: Drupal\helhist_map\MapService
-    arguments: ['@entity_type.manager']
+    arguments: ['@entity_type.manager', '@language_manager', '@entity.repository']

--- a/public/modules/custom/helhist_map/src/MapService.php
+++ b/public/modules/custom/helhist_map/src/MapService.php
@@ -1,16 +1,15 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\helhist_map\MapService.
- *
- */
+declare(strict_types=1);
 
 namespace Drupal\helhist_map;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\node\Entity\Node;
 
+/**
+ * Provides a service for map functionalities.
+ */
 class MapService {
   /**
    * The entity type manager.
@@ -20,6 +19,8 @@ class MapService {
   protected $entityTypeManager;
 
   /**
+   * Constructs a new MapService object.
+   *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
    */
@@ -27,16 +28,25 @@ class MapService {
     $this->entityTypeManager = $entity_type_manager;
   }
 
+  /**
+   * Gets the map layers for a given type.
+   *
+   * @param string $type
+   *   The type of map layers to get.
+   *
+   * @return array
+   *   An array of map layers.
+   */
   public function getMapLayers(string $type) {
     $layers = [];
     $map_layer_nodes = $this->getMapLayerNodes($type);
-    
+
     if (!$map_layer_nodes || empty($map_layer_nodes)) {
       return $layers;
     }
 
     $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
-    
+
     foreach ($map_layer_nodes as $node) {
       $node = \Drupal::service('entity.repository')->getTranslationFromContext($node, $language);
       $layer_title = $node->get('field_layer_title')->getString();
@@ -48,19 +58,28 @@ class MapService {
 
         $layer_api_endpoints[] = [
           'map_api' => $endpoint_paragraph->get('field_map_api')->getString(),
-          'wms_title' => $endpoint_paragraph->get('field_map_wms_title')->getString()
+          'wms_title' => $endpoint_paragraph->get('field_map_wms_title')->getString(),
         ];
       }
 
       $layers[$layer_title] = [
         'layer_title' => $layer_title,
-        'map_api_endpoints' => json_encode($layer_api_endpoints)
+        'map_api_endpoints' => json_encode($layer_api_endpoints),
       ];
     }
 
     return $layers;
   }
 
+  /**
+   * Gets the map layer nodes for a given type.
+   *
+   * @param string $type
+   *   The type of map layer nodes to get.
+   *
+   * @return array
+   *   An array of map layer nodes.
+   */
   private function getMapLayerNodes(string $type) {
     $query = $this->entityTypeManager
       ->getListBuilder('node')
@@ -71,7 +90,8 @@ class MapService {
       $field_condition = $query->orConditionGroup()
         ->condition('field_layer_type', $type)
         ->notExists('field_layer_type');
-    } else {
+    }
+    else {
       $field_condition = $query->andConditionGroup()
         ->condition('field_layer_type', $type);
     }
@@ -82,7 +102,7 @@ class MapService {
     $query->sort('field_layer_title', 'DESC');
 
     $map_layer_nids = $query->accessCheck(TRUE)->execute();
-    
+
     if (empty($map_layer_nids)) {
       return [];
     }

--- a/public/modules/custom/helhist_map/src/MapService.php
+++ b/public/modules/custom/helhist_map/src/MapService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\helhist_map;
 
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
@@ -66,7 +67,7 @@ class MapService {
     $layers = [];
     $map_layer_nodes = $this->getMapLayerNodes($type);
 
-    if (!$map_layer_nodes || empty($map_layer_nodes)) {
+    if (empty($map_layer_nodes)) {
       return $layers;
     }
 
@@ -74,12 +75,13 @@ class MapService {
 
     foreach ($map_layer_nodes as $node) {
       $node = $this->entityRepository->getTranslationFromContext($node, $language);
+      assert($node instanceof ContentEntityInterface);
       $layer_title = $node->get('field_layer_title')->getString();
       $map_layer_api_endpoints_field = $node->get('field_map_api_endpoints');
 
       $layer_api_endpoints = [];
       foreach ($map_layer_api_endpoints_field as $endpoint) {
-        $endpoint_paragraph = $endpoint->entity;
+        $endpoint_paragraph = $endpoint->get('entity')->getValue();
 
         $layer_api_endpoints[] = [
           'map_api' => $endpoint_paragraph->get('field_map_api')->getString(),

--- a/public/modules/custom/helhist_map/src/Plugin/Block/ComparisonMapControlsBlock.php
+++ b/public/modules/custom/helhist_map/src/Plugin/Block/ComparisonMapControlsBlock.php
@@ -1,19 +1,16 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\helhist_map\Plugin\Block\ComparisonMapControlsBlock.
- */
+declare(strict_types=1);
 
 namespace Drupal\helhist_map\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\helhist_map\MapService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Provides a Map Controls block
+ * Provides a Map Controls block.
  *
  * @Block(
  *   id = "helhist_map_comparison_map_controls_block",
@@ -22,16 +19,25 @@ use Drupal\helhist_map\MapService;
  * )
  */
 class ComparisonMapControlsBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
   /**
-   * @var \Drupal\helhist_map\MapService $map_service
+   * The map service.
+   *
+   * @var \Drupal\helhist_map\MapService
    */
   protected $mapService;
 
   /**
+   * Constructs a ComparisonMapControlsBlock object.
+   *
    * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
    * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
    * @param mixed $plugin_definition
+   *   The plugin implementation definition.
    * @param \Drupal\helhist_map\MapService $map_service
+   *   The map service.
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, MapService $map_service) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
@@ -39,10 +45,16 @@ class ComparisonMapControlsBlock extends BlockBase implements ContainerFactoryPl
   }
 
   /**
+   * Creates an instance of the plugin.
+   *
    * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   *   The container to pull out services used in the plugin.
    * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
    * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
    * @param mixed $plugin_definition
+   *   The plugin implementation definition.
    *
    * @return static
    */
@@ -62,9 +74,10 @@ class ComparisonMapControlsBlock extends BlockBase implements ContainerFactoryPl
     $build = [
       '#theme' => 'comparison_map_controls',
       '#map_layers' => $this->mapService->getMapLayers('map'),
-      '#photo_layers' => $this->mapService->getMapLayers('photo')
+      '#photo_layers' => $this->mapService->getMapLayers('photo'),
     ];
 
     return $build;
   }
+
 }

--- a/public/modules/custom/helhist_map/src/Plugin/Block/ComparisonMapControlsBlock.php
+++ b/public/modules/custom/helhist_map/src/Plugin/Block/ComparisonMapControlsBlock.php
@@ -17,6 +17,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   admin_label = @Translation("HelHist Comparison Map Controls"),
  *   category = @Translation("HelHist")
  * )
+ *
+ * @phpstan-consistent-constructor
  */
 class ComparisonMapControlsBlock extends BlockBase implements ContainerFactoryPluginInterface {
 

--- a/public/modules/custom/helhist_map/src/Plugin/Block/MapControlsBlock.php
+++ b/public/modules/custom/helhist_map/src/Plugin/Block/MapControlsBlock.php
@@ -17,6 +17,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   admin_label = @Translation("HelHist Map Controls"),
  *   category = @Translation("HelHist")
  * )
+ *
+ * @phpstan-consistent-constructor
  */
 class MapControlsBlock extends BlockBase implements ContainerFactoryPluginInterface {
   /**

--- a/public/modules/custom/helhist_map/src/Plugin/Block/MapControlsBlock.php
+++ b/public/modules/custom/helhist_map/src/Plugin/Block/MapControlsBlock.php
@@ -1,19 +1,16 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\helhist_map\Plugin\Block\MapControlsBlock.
- */
+declare(strict_types=1);
 
 namespace Drupal\helhist_map\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\helhist_map\MapService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Provides a Map Controls block
+ * Provides a Map Controls block.
  *
  * @Block(
  *   id = "helhist_map_map_controls_block",
@@ -23,15 +20,23 @@ use Drupal\helhist_map\MapService;
  */
 class MapControlsBlock extends BlockBase implements ContainerFactoryPluginInterface {
   /**
-   * @var \Drupal\helhist_map\MapService $map_service
+   * The map service.
+   *
+   * @var \Drupal\helhist_map\MapService
    */
   protected $mapService;
 
   /**
+   * Constructs a new MapControlsBlock instance.
+   *
    * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
    * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
    * @param mixed $plugin_definition
+   *   The plugin implementation definition.
    * @param \Drupal\helhist_map\MapService $map_service
+   *   The map service.
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, MapService $map_service) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
@@ -39,10 +44,16 @@ class MapControlsBlock extends BlockBase implements ContainerFactoryPluginInterf
   }
 
   /**
+   * {@inheritdoc}
+   *
    * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   *   The container to pull out services used in the plugin.
    * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
    * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
    * @param mixed $plugin_definition
+   *   The plugin implementation definition.
    *
    * @return static
    */
@@ -62,9 +73,10 @@ class MapControlsBlock extends BlockBase implements ContainerFactoryPluginInterf
     $build = [
       '#theme' => 'map_controls',
       '#map_layers' => $this->mapService->getMapLayers('map'),
-      '#photo_layers' => $this->mapService->getMapLayers('photo')
+      '#photo_layers' => $this->mapService->getMapLayers('photo'),
     ];
 
     return $build;
   }
+
 }

--- a/public/modules/custom/helhist_map/src/Plugin/Block/MapLiftBlock.php
+++ b/public/modules/custom/helhist_map/src/Plugin/Block/MapLiftBlock.php
@@ -1,20 +1,17 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\helhist_map\Plugin\Block\MapLiftBlock.
- */
+declare(strict_types=1);
 
 namespace Drupal\helhist_map\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
-use Drupal\Core\Url;
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Provides a Map Controls block
+ * Provides a Map Controls block.
  *
  * @Block(
  *   id = "helhist_map_map_lift_block",
@@ -31,13 +28,16 @@ class MapLiftBlock extends BlockBase implements ContainerFactoryPluginInterface 
   protected $languageManager;
 
   /**
+   * Constructs a MapLiftBlock instance.
+   *
    * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
    * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
    * @param mixed $plugin_definition
+   *   The plugin implementation definition.
    * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
    *   The language manager service.
-   * @param \Drupal\path_alias\AliasManagerInterface $path_alias_manager
-   *   The path alias manager service.
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, LanguageManagerInterface $language_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
@@ -45,10 +45,16 @@ class MapLiftBlock extends BlockBase implements ContainerFactoryPluginInterface 
   }
 
   /**
+   * Creates an instance of the plugin.
+   *
    * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   *   The container to pull out services used in the plugin.
    * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
    * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
    * @param mixed $plugin_definition
+   *   The plugin implementation definition.
    *
    * @return static
    */
@@ -66,15 +72,20 @@ class MapLiftBlock extends BlockBase implements ContainerFactoryPluginInterface 
    */
   public function build() {
     $language = $this->languageManager->getCurrentLanguage();
-    
+
     $map_nid = 54;
-    $map_node_url = Url::fromRoute('entity.node.canonical', ['node' => $map_nid], ['language' => $language, 'absolute' => TRUE])->toString();
+    $map_node_url = Url::fromRoute(
+      'entity.node.canonical',
+      ['node' => $map_nid],
+      ['language' => $language, 'absolute' => TRUE]
+    )->toString();
 
     $build = [
       '#theme' => 'map_lift_block',
-      '#map_node_url' => $map_node_url
+      '#map_node_url' => $map_node_url,
     ];
 
     return $build;
   }
+
 }

--- a/public/modules/custom/helhist_map/src/Plugin/Block/MapLiftBlock.php
+++ b/public/modules/custom/helhist_map/src/Plugin/Block/MapLiftBlock.php
@@ -18,6 +18,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   admin_label = @Translation("HelHist Map Lift"),
  *   category = @Translation("HelHist")
  * )
+ *
+ * @phpstan-consistent-constructor
  */
 class MapLiftBlock extends BlockBase implements ContainerFactoryPluginInterface {
   /**

--- a/public/modules/custom/helhist_media_usage/helhist_media_usage.module
+++ b/public/modules/custom/helhist_media_usage/helhist_media_usage.module
@@ -1,6 +1,13 @@
 <?php
 
 /**
+ * @file
+ * Pprovides custom media usage functionalities.
+ */
+
+declare(strict_types=1);
+
+/**
  * Implements hook_theme().
  */
 function helhist_media_usage_theme() {

--- a/public/modules/custom/helhist_media_usage/src/Plugin/Block/MediaUsageBlock.php
+++ b/public/modules/custom/helhist_media_usage/src/Plugin/Block/MediaUsageBlock.php
@@ -22,6 +22,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   admin_label = @Translation("HelHist Media Usage"),
  *   category = @Translation("HelHist")
  * )
+ *
+ * @phpstan-consistent-constructor
  */
 class MediaUsageBlock extends BlockBase implements ContainerFactoryPluginInterface {
 

--- a/public/modules/custom/helhist_media_usage/src/Plugin/Block/MediaUsageBlock.php
+++ b/public/modules/custom/helhist_media_usage/src/Plugin/Block/MediaUsageBlock.php
@@ -6,11 +6,11 @@ namespace Drupal\helhist_media_usage\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\DependencyInjection\ClassResolverInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
-use Drupal\node\Entity\Node;
 use Drupal\path_alias\AliasManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -54,6 +54,13 @@ class MediaUsageBlock extends BlockBase implements ContainerFactoryPluginInterfa
   protected $pathAliasManager;
 
   /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
    * Constructs a new ControllerBlock object.
    *
    * @param array $configuration
@@ -70,6 +77,8 @@ class MediaUsageBlock extends BlockBase implements ContainerFactoryPluginInterfa
    *   The language manager service.
    * @param \Drupal\path_alias\AliasManagerInterface $path_alias_manager
    *   The path alias manager service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
    */
   public function __construct(
     array $configuration,
@@ -78,13 +87,15 @@ class MediaUsageBlock extends BlockBase implements ContainerFactoryPluginInterfa
     ClassResolverInterface $class_resolver,
     RouteMatchInterface $route_match,
     LanguageManagerInterface $language_manager,
-    AliasManagerInterface $path_alias_manager
+    AliasManagerInterface $path_alias_manager,
+    EntityTypeManagerInterface $entity_type_manager
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->classResolver = $class_resolver;
     $this->routeMatch = $route_match;
     $this->languageManager = $language_manager;
     $this->pathAliasManager = $path_alias_manager;
+    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**
@@ -98,7 +109,8 @@ class MediaUsageBlock extends BlockBase implements ContainerFactoryPluginInterfa
       $container->get('class_resolver'),
       $container->get('current_route_match'),
       $container->get('language_manager'),
-      $container->get('path_alias.manager')
+      $container->get('path_alias.manager'),
+      $container->get('entity_type.manager')
     );
   }
 
@@ -127,7 +139,7 @@ class MediaUsageBlock extends BlockBase implements ContainerFactoryPluginInterfa
         $url_path = $this->pathAliasManager->getPathByAlias($url, $language);
         // If alias exists, we can extract node ID from path.
         if (preg_match('/node\/(\d+)/', $url_path, $matches)) {
-          $node = Node::load($matches[1]);
+          $node = $this->entityTypeManager->getStorage('node')->load($matches[1]);
         }
         if (isset($node)) {
           // Filter duplicates (old revisions, same media in liftup and

--- a/public/modules/custom/helhist_node_resave/src/Batch/NodeResaveBatch.php
+++ b/public/modules/custom/helhist_node_resave/src/Batch/NodeResaveBatch.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\helhist_node_resave\Batch;
 
 use Drupal\node\Entity\Node;
@@ -30,7 +32,8 @@ class NodeResaveBatch {
 
       if ($node->isPublished()) {
         $node->set('moderation_state', 'published');
-      } else {
+      }
+      else {
         $node->set('moderation_state', 'draft');
       }
 

--- a/public/modules/custom/helhist_node_resave/src/Form/NodeResaveForm.php
+++ b/public/modules/custom/helhist_node_resave/src/Form/NodeResaveForm.php
@@ -14,6 +14,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * Node Resave form.
  *
  * @package Drupal\helhist_node_resave\Form
+ *
+ * @phpstan-consistent-constructor
  */
 class NodeResaveForm extends FormBase {
 

--- a/public/modules/custom/helhist_node_resave/src/Form/NodeResaveForm.php
+++ b/public/modules/custom/helhist_node_resave/src/Form/NodeResaveForm.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\helhist_node_resave\Form;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;

--- a/public/modules/custom/helhist_search/helhist_search.module
+++ b/public/modules/custom/helhist_search/helhist_search.module
@@ -1,44 +1,53 @@
 <?php
 
-/** 
+/**
+ * @file
+ * Provides search functionality and custom search forms.
+ */
+
+declare(strict_types=1);
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
  * Implements hook_theme().
  */
 function helhist_search_theme($existing, $type, $theme, $path) {
   return [
     'year_interval_toggle' => [
-      'variables' => []
+      'variables' => [],
     ],
     'year_interval_field_divider' => [
-      'variables' => []
+      'variables' => [],
     ],
     'header_search' => [
       'variables' => [
-        'search_page_path' => ''
-      ]
+        'search_page_path' => '',
+      ],
     ],
     'frontpage_search' => [
       'variables' => [
-        'search_page_path' => ''
-      ]
+        'search_page_path' => '',
+      ],
     ],
     'search_frontend' => [
-      'variables' => []
-    ]
+      'variables' => [],
+    ],
   ];
 }
 
 /**
  * Implements hook_form_views_exposed_form_alter().
  */
-function helhist_search_form_views_exposed_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+function helhist_search_form_views_exposed_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   $view_ids = [
     'search',
-    'combined_map'
+    'combined_map',
   ];
 
   if ($form_id == 'views_exposed_form' && in_array($form_state->get('view')->id(), $view_ids)) {
     if ($form_state->get('view')->id() == 'search') {
-      // Move form action buttons below the Keyword-field
+      // Move form action buttons below the Keyword-field.
       $form['s']['#weight'] = -3;
       $form['actions']['#weight'] = -2;
 
@@ -47,14 +56,14 @@ function helhist_search_form_views_exposed_form_alter(&$form, \Drupal\Core\Form\
         '#tag' => 'h4',
         '#value' => t('Filter search results', [], ['context' => 'Search']),
         '#attributes' => [
-          'class' => ['search-filters-title']
+          'class' => ['search-filters-title'],
         ],
-        '#weight' => -1
+        '#weight' => -1,
       ];
     }
 
     if (array_key_exists('start_year', $form) && array_key_exists('end_year', $form)) {
-      $form['year_interval'] = _get_year_interval_render_array($form);
+      $form['year_interval'] = helhist_search__get_year_interval_render_array($form);
 
       unset($form['start_year']);
       unset($form['end_year']);
@@ -64,41 +73,44 @@ function helhist_search_form_views_exposed_form_alter(&$form, \Drupal\Core\Form\
   }
 }
 
-function _get_year_interval_render_array($form) {
+/**
+ * Helper function to get the year interval render array.
+ */
+function helhist_search__get_year_interval_render_array($form) {
   return [
     '#type' => 'container',
     '#attributes' => [
       'class' => [
         'year-interval',
-        'form-item'
-      ]
+        'form-item',
+      ],
     ],
     'toggle' => [
-      '#theme' => 'year_interval_toggle'
+      '#theme' => 'year_interval_toggle',
     ],
     'form_container' => [
       '#type' => 'container',
       '#attributes' => [
         'class' => [
           'year-interval__form',
-          'hidden'
-        ]
+          'hidden',
+        ],
       ],
       'items_container' => [
         '#type' => 'container',
         '#attributes' => [
           'class' => [
             'year-interval__form-items',
-            'hidden'
-          ]
+            'hidden',
+          ],
         ],
         'start_year' => $form['start_year'],
         'divider' => [
-          '#theme' => 'year_interval_field_divider'
+          '#theme' => 'year_interval_field_divider',
         ],
-        'end_year' => $form['end_year']
-      ]
-    ]
+        'end_year' => $form['end_year'],
+      ],
+    ],
   ];
 }
 

--- a/public/modules/custom/helhist_search/src/Plugin/Block/FrontpageSearchBlock.php
+++ b/public/modules/custom/helhist_search/src/Plugin/Block/FrontpageSearchBlock.php
@@ -17,6 +17,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   admin_label = @Translation("HelHist Frontpage Search"),
  *   category = @Translation("HelHist")
  * )
+ *
+ * @phpstan-consistent-constructor
  */
 class FrontpageSearchBlock extends BlockBase implements ContainerFactoryPluginInterface {
 

--- a/public/modules/custom/helhist_search/src/Plugin/Block/FrontpageSearchBlock.php
+++ b/public/modules/custom/helhist_search/src/Plugin/Block/FrontpageSearchBlock.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Drupal\helhist_search\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a Frontpage Search block.
@@ -15,13 +18,54 @@ use Drupal\Core\Block\BlockBase;
  *   category = @Translation("HelHist")
  * )
  */
-class FrontpageSearchBlock extends BlockBase {
+class FrontpageSearchBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The language manager service.
+   *
+   * @var \Drupal\Core\Language\LanguageManagerInterface
+   */
+  protected $languageManager;
+
+  /**
+   * Constructs a new FrontpageSearchBlock object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   *   The language manager service.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    LanguageManagerInterface $language_manager
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->languageManager = $language_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('language_manager')
+    );
+  }
 
   /**
    * {@inheritdoc}
    */
   public function build() {
-    $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    $langcode = $this->languageManager->getCurrentLanguage()->getId();
 
     switch ($langcode) {
       case "fi":

--- a/public/modules/custom/helhist_search/src/Plugin/Block/FrontpageSearchBlock.php
+++ b/public/modules/custom/helhist_search/src/Plugin/Block/FrontpageSearchBlock.php
@@ -1,16 +1,13 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\helhist_search\Plugin\Block\FrontpageSearchBlock.
- */
+declare(strict_types=1);
 
 namespace Drupal\helhist_search\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
 
 /**
- * Provides a Frontpage Search block
+ * Provides a Frontpage Search block.
  *
  * @Block(
  *   id = "helhist_search_frontpage_block",
@@ -19,31 +16,36 @@ use Drupal\Core\Block\BlockBase;
  * )
  */
 class FrontpageSearchBlock extends BlockBase {
+
   /**
    * {@inheritdoc}
    */
   public function build() {
     $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
-    
+
     switch ($langcode) {
       case "fi":
         $search_page_path = "/fi/haku";
         break;
+
       case "sv":
         $search_page_path = "/sv/sok";
         break;
+
       case "en":
         $search_page_path = "/en/search";
         break;
+
       default:
         $search_page_path = "/fi/haku";
     }
 
     $build = [
       '#theme' => 'frontpage_search',
-      '#search_page_path' => $search_page_path
+      '#search_page_path' => $search_page_path,
     ];
 
     return $build;
   }
+
 }

--- a/public/modules/custom/helhist_search/src/Plugin/Block/HeaderSearchBlock.php
+++ b/public/modules/custom/helhist_search/src/Plugin/Block/HeaderSearchBlock.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Drupal\helhist_search\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a Header Search block.
@@ -15,13 +18,54 @@ use Drupal\Core\Block\BlockBase;
  *   category = @Translation("HelHist")
  * )
  */
-class HeaderSearchBlock extends BlockBase {
+class HeaderSearchBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The language manager service.
+   *
+   * @var \Drupal\Core\Language\LanguageManagerInterface
+   */
+  protected $languageManager;
+
+  /**
+   * Constructs a new HeaderSearchBlock object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   *   The language manager service.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    LanguageManagerInterface $language_manager
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->languageManager = $language_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('language_manager')
+    );
+  }
 
   /**
    * {@inheritdoc}
    */
   public function build() {
-    $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    $langcode = $this->languageManager->getCurrentLanguage()->getId();
 
     switch ($langcode) {
       case "fi":

--- a/public/modules/custom/helhist_search/src/Plugin/Block/HeaderSearchBlock.php
+++ b/public/modules/custom/helhist_search/src/Plugin/Block/HeaderSearchBlock.php
@@ -1,16 +1,13 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\helhist_search\Plugin\Block\HeaderSearchBlock.
- */
+declare(strict_types=1);
 
 namespace Drupal\helhist_search\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
 
 /**
- * Provides a Header Search block
+ * Provides a Header Search block.
  *
  * @Block(
  *   id = "helhist_search_header_search_block",
@@ -19,31 +16,36 @@ use Drupal\Core\Block\BlockBase;
  * )
  */
 class HeaderSearchBlock extends BlockBase {
+
   /**
    * {@inheritdoc}
    */
   public function build() {
     $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
-    
+
     switch ($langcode) {
       case "fi":
         $search_page_path = "/fi/haku";
         break;
+
       case "sv":
         $search_page_path = "/sv/sok";
         break;
+
       case "en":
         $search_page_path = "/en/search";
         break;
+
       default:
         $search_page_path = "/fi/haku";
     }
 
     $build = [
       '#theme' => 'header_search',
-      '#search_page_path' => $search_page_path
+      '#search_page_path' => $search_page_path,
     ];
 
     return $build;
   }
+
 }

--- a/public/modules/custom/helhist_search/src/Plugin/Block/HeaderSearchBlock.php
+++ b/public/modules/custom/helhist_search/src/Plugin/Block/HeaderSearchBlock.php
@@ -17,6 +17,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   admin_label = @Translation("HelHist Header Search"),
  *   category = @Translation("HelHist")
  * )
+ *
+ * @phpstan-consistent-constructor
  */
 class HeaderSearchBlock extends BlockBase implements ContainerFactoryPluginInterface {
 

--- a/public/modules/custom/helhist_search/src/Plugin/Block/SearchFrontendBlock.php
+++ b/public/modules/custom/helhist_search/src/Plugin/Block/SearchFrontendBlock.php
@@ -1,16 +1,13 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\helhist_search\Plugin\Block\SearchFrontendBlock.
- */
+declare(strict_types=1);
 
 namespace Drupal\helhist_search\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
 
 /**
- * Provides a Search Frontend block
+ * Provides a Search Frontend block.
  *
  * @Block(
  *   id = "helhist_search_search_frontend_block",
@@ -19,6 +16,7 @@ use Drupal\Core\Block\BlockBase;
  * )
  */
 class SearchFrontendBlock extends BlockBase {
+
   /**
    * {@inheritdoc}
    */
@@ -27,11 +25,12 @@ class SearchFrontendBlock extends BlockBase {
       '#theme' => 'search_frontend',
       '#attached' => [
         'library' => [
-          'helhist_search/search-frontend-app'
-        ]
-      ]
+          'helhist_search/search-frontend-app',
+        ],
+      ],
     ];
 
     return $build;
   }
+
 }

--- a/public/modules/custom/helhist_search/src/Plugin/search_api/processor/ContentType.php
+++ b/public/modules/custom/helhist_search/src/Plugin/search_api/processor/ContentType.php
@@ -30,7 +30,7 @@ class ContentType extends ProcessorPluginBase {
    *
    * @var string
    */
-  protected $processor_id = 'content_type';
+  protected $processorId = 'content_type';
 
   /**
    * {@inheritdoc}
@@ -45,7 +45,7 @@ class ContentType extends ProcessorPluginBase {
         'type' => 'string',
         'processor_id' => $this->getPluginId(),
       ];
-      $properties[$this->processor_id] = new ProcessorProperty($definition);
+      $properties[$this->processorId] = new ProcessorProperty($definition);
     }
 
     return $properties;
@@ -69,7 +69,7 @@ class ContentType extends ProcessorPluginBase {
     }
 
     $fields = $this->getFieldsHelper()
-      ->filterForPropertyPath($item->getFields(), NULL, $this->processor_id);
+      ->filterForPropertyPath($item->getFields(), NULL, $this->processorId);
     foreach ($fields as $field) {
       $field->addValue($content_type);
     }

--- a/public/modules/custom/helhist_search/src/Plugin/search_api/processor/ContentType.php
+++ b/public/modules/custom/helhist_search/src/Plugin/search_api/processor/ContentType.php
@@ -1,13 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\helhist_search\Plugin\search_api\processor;
 
 use Drupal\search_api\Datasource\DatasourceInterface;
 use Drupal\search_api\Item\ItemInterface;
 use Drupal\search_api\Processor\ProcessorPluginBase;
 use Drupal\search_api\Processor\ProcessorProperty;
-use Drupal\image\Entity\ImageStyle;
-use Drupal\file\Entity\File;
 
 /**
  * Adds a custom type filter to the indexed data.
@@ -26,7 +26,8 @@ use Drupal\file\Entity\File;
 class ContentType extends ProcessorPluginBase {
 
   /**
-   * machine name of the processor.
+   * Machine name of the processor.
+   *
    * @var string
    */
   protected $processor_id = 'content_type';
@@ -35,15 +36,15 @@ class ContentType extends ProcessorPluginBase {
    * {@inheritdoc}
    */
   public function getPropertyDefinitions(DatasourceInterface $datasource = NULL) {
-    $properties = array();
+    $properties = [];
 
     if (!$datasource) {
-      $definition = array(
+      $definition = [
         'label' => $this->t('Content Type'),
         'description' => $this->t('(article / media)'),
         'type' => 'string',
         'processor_id' => $this->getPluginId(),
-      );
+      ];
       $properties[$this->processor_id] = new ProcessorProperty($definition);
     }
 
@@ -58,11 +59,11 @@ class ContentType extends ProcessorPluginBase {
 
     $entity = $item->getOriginalObject()->getValue();
     $entity_type = $entity->getEntityTypeId();
-    
+
     if ($entity_type == 'media') {
       $content_type = 'media';
     }
-  
+
     if ($entity_type == 'node') {
       $content_type = 'article';
     }
@@ -73,4 +74,5 @@ class ContentType extends ProcessorPluginBase {
       $field->addValue($content_type);
     }
   }
+
 }

--- a/public/modules/custom/helhist_search/src/Plugin/search_api/processor/ListingImageUrl.php
+++ b/public/modules/custom/helhist_search/src/Plugin/search_api/processor/ListingImageUrl.php
@@ -32,7 +32,7 @@ class ListingImageUrl extends ProcessorPluginBase {
    *
    * @var string
    */
-  protected $processor_id = 'listing_image_url';
+  protected $processorId = 'listing_image_url';
 
   /**
    * {@inheritdoc}
@@ -47,7 +47,7 @@ class ListingImageUrl extends ProcessorPluginBase {
         'type' => 'string',
         'processor_id' => $this->getPluginId(),
       ];
-      $properties[$this->processor_id] = new ProcessorProperty($definition);
+      $properties[$this->processorId] = new ProcessorProperty($definition);
     }
 
     return $properties;
@@ -84,7 +84,7 @@ class ListingImageUrl extends ProcessorPluginBase {
         $destination_url = $image_style->buildUrl($file->uri->value);
 
         $fields = $this->getFieldsHelper()
-          ->filterForPropertyPath($item->getFields(), NULL, $this->processor_id);
+          ->filterForPropertyPath($item->getFields(), NULL, $this->processorId);
         foreach ($fields as $field) {
           $field->addValue($destination_url);
         }

--- a/public/modules/custom/helhist_search/src/Plugin/search_api/processor/ListingImageUrl.php
+++ b/public/modules/custom/helhist_search/src/Plugin/search_api/processor/ListingImageUrl.php
@@ -1,13 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\helhist_search\Plugin\search_api\processor;
 
+use Drupal\file\Entity\File;
+use Drupal\image\Entity\ImageStyle;
 use Drupal\search_api\Datasource\DatasourceInterface;
 use Drupal\search_api\Item\ItemInterface;
 use Drupal\search_api\Processor\ProcessorPluginBase;
 use Drupal\search_api\Processor\ProcessorProperty;
-use Drupal\image\Entity\ImageStyle;
-use Drupal\file\Entity\File;
 
 /**
  * Adds a custom type filter to the indexed data.
@@ -26,7 +28,8 @@ use Drupal\file\Entity\File;
 class ListingImageUrl extends ProcessorPluginBase {
 
   /**
-   * machine name of the processor.
+   * Machine name of the processor.
+   *
    * @var string
    */
   protected $processor_id = 'listing_image_url';
@@ -35,15 +38,15 @@ class ListingImageUrl extends ProcessorPluginBase {
    * {@inheritdoc}
    */
   public function getPropertyDefinitions(DatasourceInterface $datasource = NULL) {
-    $properties = array();
+    $properties = [];
 
     if (!$datasource) {
-      $definition = array(
+      $definition = [
         'label' => $this->t('Listing Image URL'),
         'description' => $this->t('listing image url'),
         'type' => 'string',
         'processor_id' => $this->getPluginId(),
-      );
+      ];
       $properties[$this->processor_id] = new ProcessorProperty($definition);
     }
 
@@ -88,4 +91,5 @@ class ListingImageUrl extends ProcessorPluginBase {
       }
     }
   }
+
 }

--- a/public/modules/custom/helhist_tokens/helhist_tokens.module
+++ b/public/modules/custom/helhist_tokens/helhist_tokens.module
@@ -1,16 +1,24 @@
-<?php 
+<?php
+
+/**
+ * @file
+ * Provides Helhist custom tokens.
+ */
+
+declare(strict_types=1);
 
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\Core\Render\Markup;
+use Drupal\views\ViewExecutable;
 
 /**
  * Implements hook_token_info().
  */
 function helhist_tokens_token_info() {
-  $info['tokens']['view']['search_result_info'] = array(
+  $info['tokens']['view']['search_result_info'] = [
     'name' => t('Search result info'),
     'description' => t('Display information about currently executed search.'),
-  );
+  ];
 
   return $info;
 }
@@ -26,17 +34,17 @@ function helhist_tokens_tokens($type, $tokens, array $data, array $options, Bubb
       case 'search_result_info':
         $replacements[$original] = '';
 
-        if (!isset($data['view']) || !$data['view'] instanceof \Drupal\views\ViewExecutable) {
+        if (!isset($data['view']) || !$data['view'] instanceof ViewExecutable) {
           break;
         }
 
         $view = $data['view'];
 
         $num_of_results = $view->total_rows;
-        $search_query = isset($view->exposed_raw_input['s']) ? $view->exposed_raw_input['s'] : '';
+        $search_query = $view->exposed_raw_input['s'] ?? '';
 
         $token_content = t(
-          '@num_of_results results', 
+          '@num_of_results results',
           ['@num_of_results' => $num_of_results],
           ['context' => 'Search']
         );

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -5,6 +5,9 @@
  * Functions to support theming in the HDBT Subtheme.
  */
 
+declare(strict_types=1);
+
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\Entity\Node;
 
 /**
@@ -49,7 +52,7 @@ function hdbt_subtheme_preprocess(&$variables) {
 }
 
 /**
- * Implements hook_theme_suggestions_HOOK_alter for blocks.
+ * Implements hook_theme_suggestions_block_alter().
  */
 function hdbt_subtheme_theme_suggestions_block_alter(&$suggestions) {
   // Load theme suggestions for blocks from parent theme.
@@ -119,7 +122,8 @@ function hdbt_subtheme_preprocess_field(&$variables, $hook) {
       if ($format_term->hasTranslation('en')) {
         $english_term = $format_term->getTranslation('en');
         $term_name = $english_term->getName();
-      } else {
+      }
+      else {
         $term_name = $format_term->getName();
       }
 
@@ -135,12 +139,12 @@ function hdbt_subtheme_preprocess_field(&$variables, $hook) {
  */
 function hdbt_subtheme_theme_suggestions_field_alter(&$suggestions, $variables) {
   $taxonomy_fields = [
-    // Historiaportaali metadata fields
+    // Historiaportaali metadata fields.
     'field__field_keywords',
     'field__field_phenomena',
     'field__field_neighbourhoods',
     'field__field_turning_points',
-    // Finna metadata fields
+    // Finna metadata fields.
     'field__field_formats',
     'field__field_authors',
     'field__field_copyrights',
@@ -205,9 +209,9 @@ function hdbt_subtheme_theme_suggestions_paragraph_alter(array &$suggestions, ar
 /**
  * Implements hook_form_FORM_ID_alter().
  */
-function hdbt_subtheme_form_views_exposed_form_alter(&$form, Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+function hdbt_subtheme_form_views_exposed_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   if ($form['#id'] == 'views-exposed-form-search-page') {
-    // Hide year interval filter and add '/map' link on frontpage search block
+    // Hide year interval filter and add '/map' link on frontpage search block.
     if (\Drupal::service('path.matcher')->isFrontPage()) {
       unset($form['year_interval']);
       unset($form['search_filters_title']);
@@ -217,7 +221,7 @@ function hdbt_subtheme_form_views_exposed_form_alter(&$form, Drupal\Core\Form\Fo
       $alias = \Drupal::service('path_alias.manager')->getAliasByPath('/node/54', $langcode);
 
       $form['views_exposed_form']['#markup'] = '
-        <a class="link" href="/' . $langcode . $alias .'">
+        <a class="link" href="/' . $langcode . $alias . '">
           <span aria-hidden="true" class="hds-icon hds-icon--location"></span>
           <span class="link__label">' . $label . '</span>
         </a>';
@@ -228,7 +232,7 @@ function hdbt_subtheme_form_views_exposed_form_alter(&$form, Drupal\Core\Form\Fo
 /**
  * Implements hook_preprocess_block().
  *
- * Add a heading to fix semantics of the listing blocks
+ * Add a heading to fix semantics of the listing blocks.
  */
 function hdbt_subtheme_preprocess_block__views_block(&$variables) {
   $node = \Drupal::routeMatch()->getParameter('node');
@@ -244,7 +248,8 @@ function hdbt_subtheme_preprocess_block__views_block(&$variables) {
 /**
  * Implements hook_preprocess_block().
  *
- * Remove fallback content from message block so it doesn't get rendered when empty.
+ * Remove fallback content from message block so it doesn't get rendered when
+ * empty.
  */
 function hdbt_subtheme_preprocess_block__hdbt_messages(&$variables) {
   $variables['content']['#include_fallback'] = FALSE;
@@ -267,11 +272,20 @@ function hdbt_subtheme_preprocess_block__page_title_block(&$variables) {
   }
 }
 
+/**
+ * Helper function to get the top level menu parent title by node ID.
+ *
+ * @param int $node_id
+ *   The node ID.
+ *
+ * @return string
+ *   The top level menu parent title.
+ */
 function _get_top_level_menu_parent_title_by_nid($node_id) {
   $parent_title = '';
 
   $menu_link_manager = \Drupal::service('plugin.manager.menu.link');
-  $menu_link = $menu_link_manager->loadLinksByRoute('entity.node.canonical', array('node' => $node_id));
+  $menu_link = $menu_link_manager->loadLinksByRoute('entity.node.canonical', ['node' => $node_id]);
 
   if (is_array($menu_link) && count($menu_link)) {
     $menu_link = reset($menu_link);
@@ -364,7 +378,8 @@ function hdbt_subtheme_preprocess_paragraph(&$variables) {
         if ((intval($start) < intval($year)) && (intval($end) > intval($year))) {
           $variables['node_title'] = $name->get('field_kore_name')->value;
           $variables['node_id'] = $node[0]->id();
-        } else {
+        }
+        else {
           // Event took place on name change year.
           if (intval($start) == intval($year)) {
             $variables['node_title'] = $name->get('field_kore_name')->value;

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -34,11 +34,6 @@ function hdbt_subtheme_get_icons_path() {
   if (!isset($icon_path)) {
     $theme_handler = \Drupal::service('theme_handler');
     $icon_path = '/' . $theme_handler->getTheme('hdbt_subtheme')->getPath() . '/dist/icons/sprite.svg';
-
-    // Add icons path as a global variable.
-    if (!empty($icon_path)) {
-      return $icon_path;
-    }
   }
   return $icon_path;
 }
@@ -335,23 +330,29 @@ function hdbt_subtheme_preprocess_paragraph(&$variables) {
 
     $slide_thumbnails = [];
     $slide_thumbnails_alternative_texts = [];
-    foreach ($slides as $slide) {
-      $slide_media = $slide
-        ->get('field_gallery_slide_media')
-        ->first()
-        ->get('entity')
-        ->getTarget()
-        ->getValue();
-      $image = $slide_media
-        ->get('field_media_image')
-        ->first()
-        ->get('entity')
-        ->getTarget()
-        ->getValue();
 
+    foreach ($slides as $slide) {
+      /** @var \Drupal\paragraphs\ParagraphInterface $slide */
+
+      // Get the media entity from the slide paragraph.
+      /** @var \Drupal\media\MediaInterface|null $slide_media */
+      $slide_media = $slide->get('field_gallery_slide_media')->entity;
+      if (!$slide_media) {
+        continue;
+      }
+
+      // Get the actual image file entity from the media entity.
+      $image_field = $slide_media->get('field_media_image');
+      /** @var \Drupal\file\FileInterface|null $image */
+      $image = $image_field->entity;
+      if (!$image) {
+        continue;
+      }
+
+      // Collect caption and alt text for accessibility.
       $alternative_text = [
-        'caption' => $slide->field_gallery_slide_caption->value,
-        'alt' => $slide_media->field_media_image->first()->alt,
+        'caption' => $slide->get('field_gallery_slide_caption')->value ?? '',
+        'alt' => $image_field->first()->alt ?? '',
       ];
 
       $slide_thumbnails_alternative_texts[] = $alternative_text;


### PR DESCRIPTION
# [HIS-333](https://helsinkisolutionoffice.atlassian.net/browse/HIS-333)
[HIS-331](https://helsinkisolutionoffice.atlassian.net/browse/HIS-331) exposed number of coding violations in the old custom code.

This PR fixes old code so that tests included with automatic updates can run phpstan and phpcs. Some blocks I tried to make the code more safe and readable. Few lines ignored with `@ignore-next-line` where it was old code which apparently works so "why fix if ain't broken"..

The `graphql_search_api` module was completely ignored, as it was copied some time ago to repository from http://drupal.org/project/graphql_search_api - but it becomes obsolete after search is swapped to direct react/elasticsearch connection via [HIS-330](https://helsinkisolutionoffice.atlassian.net/browse/HIS-330).

The [helhist_kore/src/Plugin/migrate/process](https://github.com/City-of-Helsinki/historiaportaali/tree/59d2063ddca63615e9d8e0e8f177afd66fc32a15/public/modules/custom/helhist_kore/src/Plugin/migrate/process) could've possibly also ignored, it's a bit unknown for me will the migrations ever be executed again. I've understood it was a one-timer to migrate koulurekisteri to the site in the past..

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout fix/HIS-333`
  * `make fresh`
* Run `make drush-cr`

## How to test
* Check actions phpcs and phpstan tests pass
  * Or `make shell`, `phpcs` against custom code paths and `./vendor/bin/phpstan`
* Check things didn't go south on the site


[HIS-333]: https://helsinkisolutionoffice.atlassian.net/browse/HIS-333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HIS-331]: https://helsinkisolutionoffice.atlassian.net/browse/HIS-331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HIS-330]: https://helsinkisolutionoffice.atlassian.net/browse/HIS-330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ